### PR TITLE
allow custom pytype return values

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -4,7 +4,7 @@ export pyinitialize, pyfinalize, pycall, pyimport, pybuiltin, PyObject,
        pysym, PyPtr, pyincref, pydecref, pyversion, PyArray, PyArray_Info,
        pyerr_check, pyerr_clear, pytype_query, PyAny, @pyimport, PyWrapper,
        PyDict, pyisinstance, pywrap, pytypeof, pyeval, pyhassym,
-       PyVector, pystring, pyraise
+       PyVector, pystring, pyraise, pytype_mapping
 
 import Base.size, Base.ndims, Base.similar, Base.copy, Base.getindex,
        Base.setindex!, Base.stride, Base.convert, Base.pointer,

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -671,8 +671,16 @@ end
 
 let
 pytype_queries = Array((PyObject,Type),0)
-global pytype_query_add, pytype_query
-pytype_query_add(py::PyObject, jl::Type) = push!(pytype_queries, (py,jl))
+global pytype_mapping, pytype_query
+function pytype_mapping(py::PyObject, jl::Type)
+    for (i,(p,j)) in enumerate(pytype_queries)
+        if p == py
+            pytype_queries[i] = (py,jl)
+            return pytype_queries
+        end
+    end
+    push!(pytype_queries, (py,jl))
+end
 function pytype_query(o::PyObject, default::Type)
     # TODO: Use some kind of hashtable (e.g. based on PyObject_Type(o)).
     #       (A bit tricky to correctly handle Tuple and other containers.)


### PR DESCRIPTION
this extends `pytype_query()` to allow the user to add custom type mappings.

example usage (based upon SymPy):

``` julia
type Sym
     x::PyCall.PyObject
end
Sym(s::Sym) = s
convert(::Type{Sym}, o::PyCall.PyObject) = Sym(o)
PyCall.pytype_query_add(sympy.basic[Basic], Sym)
```

note: I see this would address item 3 in #9 
