### PR TITLE
Use libpython base name only in final dlopen

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -344,7 +344,7 @@ function dlopen_libpython(python::String)
             end
         end
     end
-    
+    lib = splitext(lib)[1] 
     try
         # We do this *last* because the libpython in the system
         # library path might be the wrong one if multiple python


### PR DESCRIPTION
This patch strips the extension from the libpython shared library name before the final dlopen, allowing the dynamic linker to be greedy. Without this, I get the following error on Ubuntu 13.04 (system python):

```
using PyPlot; plot(rand(10))
could not load module python: python: cannot open shared object file: No such file or directory
at /home/isaiah/.julia/PyPlot/src/PyPlot.jl:32
at In[2]:1
 in pyinitialize at /home/isaiah/.julia/PyCall/src/PyCall.jl:365
 in pyimport at /home/isaiah/.julia/PyCall/src/PyCall.jl:105
 in include at boot.jl:238
```

For background: `libpython2.7.so` does not exist as a symlink or otherwise in the standard search paths. It only exists as the symlink `/usr/lib/python2.7/config-x86_64-linux-gnu/libpython2.7.so` -> `/usr/lib/x86_64-linux-gnu/libpython2.7.so.1`. With this patch, the dynamic linker picks up the latter.
