### PR TITLE
Set PYTHONHOME based on current interpreter (Windows)

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -334,7 +334,13 @@ function dlopen_libpython(python::String)
     libpaths = [pyconfigvar(python, "LIBDIR"),
                 (@windows ? dirname(pysys(python, "executable")) : joinpath(dirname(dirname(pysys(python, "executable"))), "lib"))]
     @osx_only push!(libpaths, pyconfigvar(python, "PYTHONFRAMEWORKPREFIX"))
-    @windows_only push!(libpaths, pyconfigvar(python, "exec_prefix"))
+    @windows_only begin
+        exec_prefix = pyconfigvar(python, "exec_prefix")
+        push!(libpaths, exec_prefix)
+        if !haskey(ENV, "PYTHONHOME")
+            ENV["PYTHONHOME"] = exec_prefix
+        end
+    end
     # TODO: look in python-config output? pyconfigvar("LDFLAGS")?
     for libpath in libpaths
         if isfile(joinpath(libpath, lib))


### PR DESCRIPTION
This improves usability for non-default installations where the `python` we want is specifically executed by a startup script, but that `python` is not the system default. With this patch, IJulia (and PyPlot) run properly from the conda-notebook script, even though Anaconda was not set as default during installation (I have several python versions installed).
