### PR TITLE
Define mname for use in pyimport_name

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -680,14 +680,19 @@ end
 
 # separate this function in order to make it easier to write more
 # pyimport-like functions
-pyimport_name(name, optional_varname) =
-    let len = length(optional_varname)
-        len > 0 && (len != 2 || optional_varname[1] != :as) ? 
-        throw(ArgumentError("usage @pyimport module [as name]")) :
-        (len == 2 ? optional_varname[2] :
-         typeof(name) == Symbol ? name :
-         throw(ArgumentError("$mname is not a valid module variable name, use @pyimport $mname as <name>")))
+function pyimport_name(name, optional_varname)
+    len = length(optional_varname)
+    if len > 0 && (len != 2 || optional_varname[1] != :as)
+        throw(ArgumentError("usage @pyimport module [as name]"))
+    elseif len == 2
+        optional_varname[2]
+    elseif typeof(name) == Symbol
+        name
+    else
+        mname = modulename(name)
+        throw(ArgumentError("$mname is not a valid module variable name, use @pyimport $mname as <name>"))
     end
+end
 
 macro pyimport(name, optional_varname...)
     mname = modulename(name)

--- a/test/test.jl
+++ b/test/test.jl
@@ -64,3 +64,5 @@ array2py2arrayeq(x) = PyCall.py2array(Float64,PyCall.array2py(x)) == x
 @test_approx_eq math.sin(3) sin(3)
 
 @test collect(PyObject([1,3,5])) == [1,3,5]
+
+@test try @eval (@pyimport os.path) catch ex isa(ex, ArgumentError) end


### PR DESCRIPTION
`mname` was not defined in `pyimport_name`, and `throw(ArgumentError("$mname is not a valid module variable name, use @pyimport $mname as <name>"))` was throwing `ERROR: mname not defined`.
