### PR TITLE
faster pysym macro

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -62,6 +62,7 @@ end
 macro pysym(func)
     z, zlocal = gensym(string(func)), gensym()
     eval(current_module(),:(global $z = C_NULL))
+    z = esc(z)
     quote
         let $zlocal::Ptr{Void} = $z::Ptr{Void}
             if $zlocal == C_NULL


### PR DESCRIPTION
this is just a theory, since I haven't done testing, but I think this may compile to a faster, simpler pysym macro, since it should avoid the repeated typeassert and pointer dereference
