### PR TITLE
Support conversion of np.array with dtype=bool

### DIFF
--- a/src/numpy.jl
+++ b/src/numpy.jl
@@ -148,6 +148,7 @@ const NPY_ARRAY_ELEMENTSTRIDES = int32(0x0080)
 #########################################################################
 # conversion from Julia types to NPY_TYPES constant
 
+npy_type(::Type{Bool}) = NPY_BOOL
 npy_type(::Type{Int8}) = NPY_BYTE
 npy_type(::Type{Uint8}) = NPY_UBYTE
 npy_type(::Type{Int16}) = NPY_SHORT
@@ -162,10 +163,11 @@ npy_type(::Type{Complex64}) = NPY_CFLOAT
 npy_type(::Type{Complex128}) = NPY_CDOUBLE
 npy_type(::Type{PyPtr}) = NPY_OBJECT
 
-typealias NPY_TYPES Union(Int8,Uint8,Int16,Uint16,Int32,Uint32,Int64,Uint64,Float32,Float64,Complex64,Complex128,PyPtr)
+typealias NPY_TYPES Union(Bool,Int8,Uint8,Int16,Uint16,Int32,Uint32,Int64,Uint64,Float32,Float64,Complex64,Complex128,PyPtr)
 
 # conversions from __array_interface__ type strings to supported Julia types
-const npy_typestrs = (String=>Type)[ "i1"=>Int8, "u1"=>Uint8,
+const npy_typestrs = (String=>Type)[ "b1"=>Bool,
+                                     "i1"=>Int8, "u1"=>Uint8,
                                      "i2"=>Int16, "u2"=>Uint16,
                                      "i4"=>Int32, "u4"=>Uint32,
                                      "i8"=>Int64, "u8"=>Uint64,


### PR DESCRIPTION
I noticed that np.array with dtype=bool was not getting converted to a Julia array.

This PR seems to fix it. For example:

```
np.array([true, false])
```

now returns Array{Bool,1}
