### PR TITLE
Allow display of objects that override attrs

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -869,7 +869,7 @@ for (mime, method) in ((MIME"text/html", "_repr_html_"),
             throw(MethodError(writemime, (io, mime, o)))
         end
         mimewritable(::$mime, o::PyObject) =
-            o.o != C_NULL && haskey(o, $method) &&
+            o.o != C_NULL && haskey(o, $method) && o[$method].o != pynothing::PyPtr &&
             pycall(o[$method], PyObject).o != pynothing::PyPtr
     end
 end


### PR DESCRIPTION
The BeautifulSoup library overrides object attributes such that `haskey(o, :anything)` always returns true.  This simply adds a check in mimewriteable to make sure that `o[$method]` is not `None` before trying to call it.

I am not a Python programmer, so I do not know how common or accepted this idiom is.  But it makes BeautifulSoup objects behave better.
