### PR TITLE
Added weak references support to jlwrap types (for #21 and #158)

### DIFF
--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -122,6 +122,9 @@ function __init__()
         PyMemberDef[ PyMemberDef(pyjlwrap_membername,
                                  T_PYSSIZET, sizeof_PyObject_HEAD, READONLY,
                                  pyjlwrap_doc),
+                     PyMemberDef(weakreflist_membername,
+                                 T_OBJECT_EX, sizeof_PyObject_HEAD+sizeof(PyPtr), 0,
+                                 weakreflist_doc),
                      PyMemberDef(C_NULL,0,0,0,C_NULL) ]
 
     init_datetime()

--- a/src/pytype.jl
+++ b/src/pytype.jl
@@ -340,12 +340,17 @@ immutable Py_jlWrap
     # PyObject_HEAD (for non-Py_TRACE_REFS build):
     ob_refcnt::Int
     ob_type::PyPtr
-
+    
     jl_value::Any
+    ob_weakreflist::PyPtr #list of weak references
 end
 
 # destructor for jlwrap instance, assuming it was created with pyjlwrap_new
 function pyjlwrap_dealloc(o::PyPtr)
+    #Delete weak reference list
+    ccall((@pysym :PyObject_ClearWeakRefs), Void,
+          (PyPtr,), o)
+    
     delete!(pycall_gc, o)
     return nothing
 end
@@ -379,6 +384,8 @@ end
 # constant strings (must not be gc'ed) for pyjlwrap_members
 const pyjlwrap_membername = "jl_value"
 const pyjlwrap_doc = "Julia jl_value_t* (Any object)"
+const weakreflist_membername = "ob_weakreflist"
+const weakreflist_doc = "List of weak references"
 
 # called in __init__
 function pyjlwrap_init()
@@ -391,6 +398,8 @@ function pyjlwrap_init()
                          t.tp_repr = pyjlwrap_repr_ptr
                          t.tp_hash = sizeof(Py_hash_t) < sizeof(Int) ?
                          pyjlwrap_hash32_ptr : pyjlwrap_hash_ptr
+                         t.tp_weaklistoffset = fieldoffsets(Py_jlWrap)[4] #set to actual offset
+                         t.tp_flags |= Py_TPFLAGS_HAVE_WEAKREFS #set weak refs bit
                      end)
 end
 
@@ -416,6 +425,7 @@ function pyjlwrap_new(pyT::PyTypeObject, value::Any)
     pycall_gc[o.o] = value
     p = convert(Ptr{Ptr{Void}}, o.o)
     unsafe_store!(p, ccall(:jl_value_ptr, Ptr{Void}, (Any,), value), 3)
+    unsafe_store!(p, C_NULL, 4) #initiate weakreflist as NULL
     return o
 end
 


### PR DESCRIPTION
I've managed to get weak references to work (#158), and have mainly tested it directly with the python weakref module and on julia functions:

```
using PyCall
@pyimport weakref

po = PyObject(x -> x + 1)  #create jl_FunctionType
r = weakref.ref(po)
r()                        #returns (anonymous function)

po = 1                     #remove reference to the PyObject
gc()                       #run gc
r()                        #returns nothing
```

I've also tested it on connecting julia functions to matplotlib's figure events:

```
import PyPlot.plt

plt[:plot]()
fig = plt[:gcf]()
onpress(mev) = println("($(mev[:xdata]),$(mev[:ydata]))")
cid = fig[:canvas][:mpl_connect]("button_press_event", onpress)
```

Left clicking within the axes outputs pairs of data coordinates at the location of the click.
