### PR TITLE
Fix writemime deprecation warnings

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -695,7 +695,7 @@ for (mime, method) in ((MIME"text/html", "_repr_html_"),
                 r = pycall(o[$method], PyObject)
                 r.o != pynothing[] && return write(io, convert($T, r))
             end
-            throw(MethodError(VERSION < v"0.5.0-dev+4340" ? writemime : show,
+            throw(MethodError($(VERSION < v"0.5.0-dev+4340") ? writemime : show,
                               (io, mime, o)))
         end
         mimewritable(::$mime, o::PyObject) =


### PR DESCRIPTION
In IJulia, I sometimes get deprecation warnings from PyCall. Eg.

```julia
using PyCall
@pyimport math
math.sin
```

(has to be run in three different cells!)

This PR fixes this for Julia 0.5.