### PR TITLE
Fix reliance on an old macro hygiene bug that broke in julia v0.6

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -742,7 +742,7 @@ end
 
 macro return_not_None(ex)
     quote
-        T = $ex
+        T = $(esc(ex))
         if T != Union{}
             return T
         end

--- a/src/exception.jl
+++ b/src/exception.jl
@@ -69,13 +69,13 @@ callsym(ex::Expr) = isexpr(ex,:macrocall,2) ? callsym(ex.args[2]) : isexpr(ex,:c
 
 # Macros for common pyerr_check("Foo", ccall((@pysym :Foo), ...)) pattern.
 macro pycheck(ex)
-    :(pyerr_check($(string(callsym(ex))), $ex))
+    :(pyerr_check($(string(callsym(ex))), $(esc(ex))))
 end
 
 # Macros to check that ccall((@pysym :Foo), ...) returns value != bad
 macro pycheckv(ex, bad)
     quote
-        val = $ex
+        val = $(esc(ex))
         if val == $bad
             # throw a PyError if available, otherwise throw ErrorException
             pyerr_check($(string(callsym(ex))))
@@ -85,10 +85,10 @@ macro pycheckv(ex, bad)
     end
 end
 macro pycheckn(ex)
-    :(@pycheckv $ex C_NULL)
+    :(@pycheckv $(esc(ex)) C_NULL)
 end
 macro pycheckz(ex)
-    :(@pycheckv $ex -1)
+    :(@pycheckv $(esc(ex)) -1)
 end
 
 #########################################################################


### PR DESCRIPTION
Macros that attempt to interpolate expressions should do so with

```julia
$(esc(ex))
```

rather than

```julia
$ex
```

This worked on 0.5 (though it apparently shouldn't have), but is now
broken on 0.6.

Fixes #332

See the discussion at https://github.com/JuliaLang/julia/issues/19587