### PR TITLE
Fix a few depwarns and errors on 0.6

### DIFF
--- a/src/numpy.jl
+++ b/src/numpy.jl
@@ -261,7 +261,7 @@ type PyArray_Info
 end
 
 aligned(i::PyArray_Info) = #  FIXME: also check pointer alignment?
-  all(m -> m == 0, mod(i.st, sizeof(i.T))) # strides divisible by elsize
+  @compat all(m -> m == 0, mod.(i.st, sizeof(i.T))) # strides divisible by elsize
 
 # whether a contiguous array in column-major (Fortran, Julia) order
 function f_contiguous(T::Type, sz::Vector{Int}, st::Vector{Int})
@@ -318,7 +318,7 @@ type PyArray{T,N} <: AbstractArray{T,N}
         elseif length(info.sz) != N || length(info.st) != N
             throw(ArgumentError("inconsistent ndims in PyArray constructor"))
         end
-        return new(o, info, tuple(info.sz...), div(info.st, sizeof(T)),
+        return new(o, info, tuple(info.sz...), @compat(div.(info.st, sizeof(T))),
                    f_contiguous(info), c_contiguous(info),
                    convert(Ptr{T}, info.data))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,6 @@ import PyCall.pyany_toany
 @test roundtripeq(Int32)
 @test roundtripeq(Dict(1 => "hello", 2 => "goodbye")) && roundtripeq(Dict())
 @test roundtripeq(UInt8[1,3,4,5])
-@test convert(Vector{UInt8}, "hello") == "hello".data
 @test roundtrip(3 => 4) == (3,4)
 @test roundtrip(Pair{Int,Int}, 3 => 4) == Pair(3,4)
 


### PR DESCRIPTION
The two errors I left unchanged are

* https://github.com/JuliaPy/PyCall.jl/issues/343

    Seems that the solution haven't been finalized yet.

* https://github.com/JuliaLang/julia/issues/19987

    Let's see if this can be unbroken in Base. ~~This particular line seems to be really good at catching base parser breakage...~~ (actually it was a different line)
