### PR TITLE
Fix 0.6 depwarns

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -31,6 +31,10 @@ import Compat.String
 import Base.unsafe_convert
 import MacroTools   # because of issue #270
 
+if isdefined(Base, :Iterators)
+    import Base.Iterators: filter
+end
+
 #########################################################################
 
 include(joinpath(dirname(@__FILE__), "..", "deps","depsutils.jl"))

--- a/src/pydates.jl
+++ b/src/pydates.jl
@@ -88,11 +88,11 @@ PyDelta_FromDSU(days, seconds, useconds) =
                              days, seconds, useconds,
                              1, DeltaType[]))
 
-PyObject(p::Dates.Day) = PyDelta_FromDSU(Int(p), 0, 0)
+PyObject(p::Dates.Day) = PyDelta_FromDSU(Dates.value(p), 0, 0)
 
 function PyObject(p::Dates.Second)
     # normalize to make Cint overflow less likely
-    s = Int(p)
+    s = Dates.value(p)
     d = div(s, 86400)
     s -= d * 86400
     PyDelta_FromDSU(d, s, 0)
@@ -100,7 +100,7 @@ end
 
 function PyObject(p::Dates.Millisecond)
     # normalize to make Cint overflow less likely
-    ms = Int(p)
+    ms = Dates.value(p)
     s = div(ms, 1000)
     ms -= s * 1000
     d = div(s, 86400)

--- a/src/pyeval.jl
+++ b/src/pyeval.jl
@@ -192,7 +192,9 @@ macro py_str(code, options...)
     code, locals = interpolate_pycode(code)
     input_type = '\n' in code ? Py_file_input : Py_eval_input
     fname = make_fname(@__FILE__)
-    assignlocals = Expr(:block, [:(m[$v] = PyObject($(esc(ex)))) for (v,ex) in locals if isa(v,String)]...)
+    assignlocals = Expr(:block, [(isa(v,String) ?
+                                  :(m[$v] = PyObject($(esc(ex)))) :
+                                  nothing) for (v,ex) in locals]...)
     code_expr = Expr(:call, esc(:(Base.string)))
     i0 = start(code)
     for i in sort!(collect(filter(k -> isa(k,Integer), keys(locals))))


### PR DESCRIPTION
Test on master might fail with an error similar to

```
signal (4): Illegal instruction
while loading /home/yuyichao/projects/contrib/PyCall.jl/test/runtests.jl, in expression starting on line 318
copy at /usr/share/julia/site/v0.6/PyCall/src/numpy.jl:340
unknown function (ip: 0x7fe154c964f2)
jl_call_method_internal at /build/julia-git/src/julia-avx2/src/julia_internal.h:248
```

and that's https://github.com/JuliaLang/julia/issues/20305

I also decided to work around https://github.com/JuliaLang/julia/issues/19987 since it doesn't seems to have very high priority or trivial to fix (but trivial to workaround)....
