### PR TITLE
Make dictionary conversion more conservative

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -697,10 +697,10 @@ pyfunction_query(o::PyObject) = Union{}
 
 pynothing_query(o::PyObject) = o.o == pynothing[] ? Void : Union{}
 
-# we check for "items" attr since PyMapping_Check doesn't do this (it only
-# checks for __getitem__) and PyMapping_Check returns true for some
-# scipy scalar array members, grrr.
-pydict_query(o::PyObject) = pyisinstance(o, @pyglobalobj :PyDict_Type) || (pyquery((@pyglobal :PyMapping_Check), o) && ccall((@pysym :PyObject_HasAttrString), Cint, (PyPtr,Ptr{UInt8}), o, "items") == 1) ? Dict{PyAny,PyAny} : Union{}
+# We refrain from converting all objects that support the mapping protocol (PyMapping_Check)
+# to avoid converting types like Pandas `DataFrame` that are only lossily
+# representable as a Julia dictionary (issue #376).
+pydict_query(o::PyObject) = pyisinstance(o, @pyglobalobj :PyDict_Type) ? Dict{PyAny,PyAny} : Union{}
 
 typetuple(Ts) = Tuple{Ts...}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -341,7 +341,7 @@ end
 let weakdict = pyimport("weakref")["WeakValueDictionary"]
     # (use weakdict for the value, since Python supports
     #  weak references to type objects)
-    @test weakdict(Dict(3=>weakdict)) == Dict(3=>weakdict)
+    @test weakdict(Dict(3=>weakdict))[:__getitem__](3) == weakdict
 end
 
 # Expose python docs to Julia doc system

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -341,7 +341,8 @@ end
 let weakdict = pyimport("weakref")["WeakValueDictionary"]
     # (use weakdict for the value, since Python supports
     #  weak references to type objects)
-    @test weakdict(Dict(3=>weakdict))[:__getitem__](3) == weakdict
+    @test convert(Dict{Int,PyObject}, weakdict(Dict(3=>weakdict))) == Dict(3=>weakdict)
+    @test get(weakdict(Dict(3=>weakdict)),3) == weakdict
 end
 
 # Expose python docs to Julia doc system


### PR DESCRIPTION
Stop mapping all Python objects that support the mapping protocol to
Julia dictionaries.