### PR TITLE
Custom serialization for PyObject

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -760,6 +760,7 @@ end
 #########################################################################
 
 include("pyeval.jl")
+include("serialize.jl")
 
 #########################################################################
 # Precompilation: just an optimization to speed up initialization.

--- a/src/serialize.jl
+++ b/src/serialize.jl
@@ -1,0 +1,18 @@
+const pickle = PyNULL()
+
+function get_pickle()
+    if pickle.o == C_NULL
+        copy!(pickle, pyimport("pickle"))
+    end
+
+    return pickle
+end
+
+function Base.serialize(s::AbstractSerializer, pyo::PyObject)
+    Base.serialize_type(s, PyObject)
+    serialize(s, get_pickle()[:dumps](pyo))
+end
+
+function Base.deserialize(s::AbstractSerializer, t::Type{PyObject})
+    get_pickle()[:loads](deserialize(s))
+end

--- a/src/serialize.jl
+++ b/src/serialize.jl
@@ -3,6 +3,7 @@ const _pickle = PyNULL()
 pickle() = _pickle.o == C_NULL ? copy!(_pickle, pyimport(PyCall.pyversion.major ≥ 3 ? "pickle" : "cPickle")) : _pickle
 
 function Base.serialize(s::AbstractSerializer, pyo::PyObject)
+    pyo.o == C_NULL && return invoke(serialize, (AbstractSerializer, Any), s, pyo)
     Base.serialize_type(s, PyObject)
     b = PyBuffer(pycall(pickle()["dumps"], PyObject, pyo))
     serialize(s, unsafe_wrap(Array, Ptr{UInt8}(pointer(b)), sizeof(b)))
@@ -10,7 +11,7 @@ end
 
 function Base.deserialize(s::AbstractSerializer, t::Type{PyObject})
     b = deserialize(s)
-    pycall(pickle()["loads"], PyObject,
+    return isa(b, PyPtr) ? PyObject(b) : pycall(pickle()["loads"], PyObject,
         PyObject(@pycheckn ccall(@pysym(PyString_FromStringAndSize),
                 PyPtr, (Ptr{UInt8}, Int),
                 b, sizeof(b))))

--- a/src/serialize.jl
+++ b/src/serialize.jl
@@ -3,16 +3,24 @@ const _pickle = PyNULL()
 pickle() = _pickle.o == C_NULL ? copy!(_pickle, pyimport(PyCall.pyversion.major ≥ 3 ? "pickle" : "cPickle")) : _pickle
 
 function Base.serialize(s::AbstractSerializer, pyo::PyObject)
-    pyo.o == C_NULL && return invoke(serialize, (AbstractSerializer, Any), s, pyo)
     Base.serialize_type(s, PyObject)
-    b = PyBuffer(pycall(pickle()["dumps"], PyObject, pyo))
-    serialize(s, unsafe_wrap(Array, Ptr{UInt8}(pointer(b)), sizeof(b)))
+    if pyo.o == C_NULL
+        serialize(s, pyo.o)
+    else
+        b = PyBuffer(pycall(pickle()["dumps"], PyObject, pyo))
+        serialize(s, unsafe_wrap(Array, Ptr{UInt8}(pointer(b)), sizeof(b)))
+    end
 end
 
 function Base.deserialize(s::AbstractSerializer, t::Type{PyObject})
     b = deserialize(s)
-    return isa(b, PyPtr) ? PyObject(b) : pycall(pickle()["loads"], PyObject,
-        PyObject(@pycheckn ccall(@pysym(PyString_FromStringAndSize),
-                PyPtr, (Ptr{UInt8}, Int),
-                b, sizeof(b))))
+    if isa(b, PyPtr)
+        @assert b == C_NULL
+        return PyNULL()
+    else
+        return pycall(pickle()["loads"], PyObject,
+            PyObject(@pycheckn ccall(@pysym(PyString_FromStringAndSize),
+                    PyPtr, (Ptr{UInt8}, Int),
+                    b, sizeof(b))))
+    end
 end

--- a/src/serialize.jl
+++ b/src/serialize.jl
@@ -1,29 +1,28 @@
 const _pickle = PyNULL()
 
-pickle() = _pickle.o == C_NULL ? copy!(_pickle, pyimport("pickle")) : _pickle
+function pickle()
+    if _pickle.o == C_NULL
+        if pyexists(:cPickle)
+            copy!(_pickle, pyimport(:cPickle))
+        else
+            copy!(_pickle, pyimport(:pickle))
+        end
+    end
+
+    return _pickle
+end
 
 function Base.serialize(s::AbstractSerializer, pyo::PyObject)
     Base.serialize_type(s, PyObject)
-
-    b = PyBuffer(pycall(pickle()[:dumps], PyObject, pyo))
-
+    b = PyBuffer(pycall(pickle()["dumps"], PyObject, pyo))
     serialize(s, unsafe_wrap(Array, Ptr{UInt8}(pointer(b)), sizeof(b)))
 end
 
 function Base.deserialize(s::AbstractSerializer, t::Type{PyObject})
     b = deserialize(s)
 
-    pycall(
-        pickle()[:loads],
-        PyObject,
-        PyObject(
-            @pycheckn ccall(
-                @pysym(PyString_FromStringAndSize),
-                PyPtr,
-                (Ptr{UInt8}, Int),
-                b,
-                sizeof(b)
-            )
-        )
-    )
+    pycall(pickle()["loads"], PyObject,
+        PyObject(@pycheckn ccall(@pysym(PyString_FromStringAndSize),
+                PyPtr, (Ptr{UInt8}, Int),
+                b, sizeof(b))))
 end

--- a/src/serialize.jl
+++ b/src/serialize.jl
@@ -1,16 +1,6 @@
 const _pickle = PyNULL()
 
-function pickle()
-    if _pickle.o == C_NULL
-        if pyexists(:cPickle)
-            copy!(_pickle, pyimport(:cPickle))
-        else
-            copy!(_pickle, pyimport(:pickle))
-        end
-    end
-
-    return _pickle
-end
+pickle() = _pickle.o == C_NULL ? copy!(_pickle, pyimport(PyCall.pyversion.major ≥ 3 ? "pickle" : "cPickle")) : _pickle
 
 function Base.serialize(s::AbstractSerializer, pyo::PyObject)
     Base.serialize_type(s, PyObject)
@@ -20,7 +10,6 @@ end
 
 function Base.deserialize(s::AbstractSerializer, t::Type{PyObject})
     b = deserialize(s)
-
     pycall(pickle()["loads"], PyObject,
         PyObject(@pycheckn ccall(@pysym(PyString_FromStringAndSize),
                 PyPtr, (Ptr{UInt8}, Int),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -385,7 +385,12 @@ end
 @test Bool(PyVector{PyObject}(PyObject([false]))[1]) === false
 
 # serialization
-let py_sum_obj = pybuiltin("sum"), b = IOBuffer()
+let py_sum_obj = pybuiltin("sum")
+    b = IOBuffer()
     serialize(b, py_sum_obj)
     @test py_sum_obj == deserialize(seekstart(b))
+
+    b = IOBuffer()
+    serialize(b, PyNULL())
+    @test PyNULL() == deserialize(seekstart(b))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -383,3 +383,8 @@ end
 @test convert(Bool, PyObject(17.3)) === true
 @test convert(Bool, PyObject(Any[0])) === true
 @test Bool(PyVector{PyObject}(PyObject([false]))[1]) === false
+
+# serialization
+let py_sum_obj = pybuiltin("sum")
+    @test py_sum_obj == deserialize(IOBuffer(sprint(io->serialize(io, py_sum_obj))))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -385,6 +385,7 @@ end
 @test Bool(PyVector{PyObject}(PyObject([false]))[1]) === false
 
 # serialization
-let py_sum_obj = pybuiltin("sum")
-    @test py_sum_obj == deserialize(IOBuffer(sprint(io->serialize(io, py_sum_obj))))
+let py_sum_obj = pybuiltin("sum"), b = IOBuffer()
+    serialize(b, py_sum_obj)
+    @test py_sum_obj == deserialize(seekstart(b))
 end


### PR DESCRIPTION
This is my first crack at doing this. This allows passing PyObjects around in RemoteChannels. 

One issue with this:

This works:
```julia
using PyCall
@everywhere using PyCall
```

But this segfaults:
```julia
@everywhere using PyCall
```

I know the latter does the NxN loading thing and isn't advized, but it's something people will do. Advice is welcome!