### PR TITLE
Allow calling things that are not Functions

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -859,7 +859,7 @@ include("serialize.jl")
 # Here, we precompile functions that are passed to cfunction by __init__,
 # for the reasons described in JuliaLang/julia#12256.
 
-precompile(jl_Function_call, (PyPtr,PyPtr,PyPtr))
+precompile(pyjlwrap_call, (PyPtr,PyPtr,PyPtr))
 precompile(pyjlwrap_dealloc, (PyPtr,))
 precompile(pyjlwrap_repr, (PyPtr,))
 precompile(pyjlwrap_hash, (PyPtr,))

--- a/src/callback.jl
+++ b/src/callback.jl
@@ -21,13 +21,13 @@ end
 
 ################################################################
 
-# To pass an arbitrary Julia function to Python, we wrap it
-# in a jl_Function Python class, where jl_Function.__call__
-# executes the jl_Function_callback function in Julia, which
-# in turn fetches the actual Julia function from the "f" attribute
+# To pass an arbitrary Julia object to Python, we wrap it
+# in a jlwrap Python class, where jlwrap.__call__
+# executes the pyjlwrap_call function in Julia, which
+# in turn fetches the actual Julia value from the python wrapper
 # and calls it.
 
-function jl_Function_call(self_::PyPtr, args_::PyPtr, kw_::PyPtr)
+function pyjlwrap_call(self_::PyPtr, args_::PyPtr, kw_::PyPtr)
     args = PyObject(args_) # don't need pyincref because of finally clause below
     try
         f = unsafe_pyjlwrap_to_objref(self_)
@@ -65,42 +65,4 @@ function jl_Function_call(self_::PyPtr, args_::PyPtr, kw_::PyPtr)
     return PyPtr_NULL
 end
 
-# just string(Docs.doc(f)) doesn't work on VERSION < v"0.5"
-function docstring(f::Function)
-    buf = IOBuffer()
-    show(buf, "text/plain", Docs.doc(f))
-    return String(take!(buf))
-end
-
-# this function emulates standard attributes of Python functions,
-# where possible.
-function jl_Function_getattr(self_::PyPtr, attr__::PyPtr)
-    attr_ = PyObject(attr__) # don't need pyincref because of finally clause below
-    try
-        f = unsafe_pyjlwrap_to_objref(self_)::Function
-        attr = convert(String, attr_)
-        if attr in ("__name__","func_name")
-            return pystealref!(PyObject(string(f)))
-        elseif attr in ("__doc__", "func_doc")
-            return pystealref!(PyObject(docstring(f)))
-        elseif attr in ("__module__","__defaults__","func_defaults","__closure__","func_closure")
-            return pystealref!(PyObject(nothing))
-        else
-            # TODO: handle __code__/func_code (issue #268)
-
-            # fallback: (probably raises AttributeError)
-            return ccall(@pysym(:PyObject_GenericGetAttr), PyPtr, (PyPtr,PyPtr), self_, attr__)
-        end
-    catch e
-        pyraise(e)
-    finally
-        attr_.o = PyPtr_NULL # don't decref
-    end
-    return PyPtr_NULL
-end
-
-function pycallback(f::Function)
-    pyjlwrap_new(jl_FunctionType, f)
-end
-
-PyObject(f::Function) = pycallback(f)
+pycallback(f::Function) = PyObject(f)

--- a/src/callback.jl
+++ b/src/callback.jl
@@ -64,5 +64,3 @@ function pyjlwrap_call(self_::PyPtr, args_::PyPtr, kw_::PyPtr)
     end
     return PyPtr_NULL
 end
-
-pycallback(f::Function) = PyObject(f)

--- a/src/callback.jl
+++ b/src/callback.jl
@@ -30,7 +30,7 @@ end
 function jl_Function_call(self_::PyPtr, args_::PyPtr, kw_::PyPtr)
     args = PyObject(args_) # don't need pyincref because of finally clause below
     try
-        f = unsafe_pyjlwrap_to_objref(self_)::Function
+        f = unsafe_pyjlwrap_to_objref(self_)
 
         # on 0.6 we need to use invokelatest to get execution in newest world
         @static if isdefined(Base, :invokelatest)

--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -76,7 +76,7 @@ function __init__()
     init_datetime()
     pyjlwrap_init()
 
-    # jl_FunctionType is a class, and when assigning it to an object
+    # jlwrap is a class, and when assigning it to an object
     #    obj[:foo] = some_julia_function
     # it won't behave like a regular Python method because it's not a Python
     # function (in particular, `self` won't be passed to it). The solution is:

--- a/src/pytype.jl
+++ b/src/pytype.jl
@@ -400,6 +400,7 @@ function pyjlwrap_init()
                      t.tp_members = pointer(pyjlwrap_members);
                      t.tp_dealloc = pyjlwrap_dealloc_ptr
                      t.tp_repr = pyjlwrap_repr_ptr
+                     t.tp_call = jl_Function_call_ptr
                      t.tp_hash = sizeof(Py_hash_t) < sizeof(Int) ?
                      pyjlwrap_hash32_ptr : pyjlwrap_hash_ptr
                   end)

--- a/src/pytype.jl
+++ b/src/pytype.jl
@@ -363,12 +363,7 @@ function pyjlwrap_hash32(o::PyPtr)
     return h == reinterpret(UInt32, Int32(-1)) ? pysalt32 : h::UInt32
 end
 
-# just string(Docs.doc(f)) doesn't work on VERSION < v"0.5"
-function docstring(f::Function)
-    buf = IOBuffer()
-    show(buf, "text/plain", Docs.doc(f))
-    return String(take!(buf))
-end
+docstring(x) = string(Docs.doc(x))
 
 # this function emulates standard attributes of Python functions,
 # where possible.

--- a/src/pytype.jl
+++ b/src/pytype.jl
@@ -383,11 +383,11 @@ function pyjlwrap_getattr(self_::PyPtr, attr__::PyPtr)
             return pystealref!(PyObject(docstring(f)))
         elseif attr in ("__module__","__defaults__","func_defaults","__closure__","func_closure")
             return pystealref!(PyObject(nothing))
-        else
+        elseif startswith(attr, "__")
             # TODO: handle __code__/func_code (issue #268)
-
-            # fallback: (probably raises AttributeError)
             return ccall(@pysym(:PyObject_GenericGetAttr), PyPtr, (PyPtr,PyPtr), self_, attr__)
+        else
+            return pystealref!(PyObject(getfield(f, Symbol(attr))))
         end
     catch e
         pyraise(e)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -471,3 +471,9 @@ let p = PyCall.pickle(), buf = IOBuffer()
     @test p[:load](buf) == 314159
     @test p[:load](buf) == [1,1,2,3,5,8]
 end
+
+# Test that we can call constructors on the python side
+immutable TestConstruct
+    x
+end
+@test pycall(PyObject(TestConstruct), PyAny, 1).x == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -477,3 +477,6 @@ immutable TestConstruct
     x
 end
 @test pycall(PyObject(TestConstruct), PyAny, 1).x == 1
+
+# Test getattr fallback
+PyObject(TestConstruct(1))[:x] == 1


### PR DESCRIPTION
All objects are callable nowadays, restricting to `Function` is odd and
precludes things like constructing types from Python in pyjulia.