### PR TITLE
Tighten return type for conversion to `Array`

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -392,7 +392,7 @@ function convert{T}(::Type{Vector{T}}, o::PyObject)
     py2array(T, Array{pyany_toany(T)}(len), o, 1, 1)
 end
 
-convert(::Type{Array}, o::PyObject) = py2array(PyAny, o)
+convert(::Type{Array}, o::PyObject) = map(identity, py2array(PyAny, o))
 convert{T}(::Type{Array{T}}, o::PyObject) = py2array(T, o)
 
 PyObject(a::BitArray) = PyObject(Array(a))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,9 @@ import PyCall.pyany_toany
 @test roundtripeq(UInt8[1,3,4,5])
 @test roundtrip(3 => 4) == (3,4)
 @test roundtrip(Pair{Int,Int}, 3 => 4) == Pair(3,4)
+if VERSION >= v"0.6.0"
+    @test eltype(roundtrip([Ref(1), Ref(2)])) == typeof(Ref(1))
+end
 
 @test pycall(PyObject(x -> x + 1), PyAny, 314158) == 314159
 @test PyObject(x -> x + 1)(314158) == 314159


### PR DESCRIPTION
Makes the following work in pyjulia:
```python
import julia
j = julia.Julia()
j.eval("""
module FooBar
export Foo, bar
type Foo
  i::Int
end
function bar(a::Array{Foo,1})
  return sum([f.i for f in a])
end
end # module
""")
j.using("FooBar")
foo1 = j.Foo(1)
foo2 = j.Foo(2)
j.bar([foo1, foo2])
```

before this would fail because the julia-side type was `Vector{Any}`.