### PR TITLE
fixed missing conversion of Int128

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -653,24 +653,17 @@ end
 pymp_query(o::PyObject) = pyisinstance(o, mpf) ? BigFloat : pyisinstance(o, mpc) ? Complex{BigFloat} : Union{}
 
 #########################################################################
-# Int128 and BigInt conversion to Python "long" integers
+# (Int64), Int128 and BigInt conversion to Python "long" integers
 
-function PyObject(i::Union{Int128,BigInt})
+const LongInt = @static (Sys.WORD_SIZE==32) ? Union{Int64,UInt64,Int128,UInt128,BigInt} : Union{Int128,UInt128,BigInt}
+
+function PyObject(i::LongInt)
     PyObject(@pycheckn ccall((@pysym :PyLong_FromString), PyPtr,
                              (Ptr{UInt8}, Ptr{Void}, Cint),
                              String(string(i)), C_NULL, 10))
 end
 
 convert(::Type{BigInt}, o::PyObject) = parse(BigInt, pystr(o))
-
-# If 32-bit systems are used, Int64 has to be converted to long integes as well.
-@static if Int == Int32
-    function PyObject(i::Int64)
-        PyObject(@pycheckn ccall((@pysym :PyLong_FromString), PyPtr,
-                                 (Ptr{UInt8}, Ptr{Void}, Cint),
-                                 String(string(i)), C_NULL, 10))
-    end
-end
 
 #########################################################################
 # Dates (Calendar time)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -653,9 +653,9 @@ end
 pymp_query(o::PyObject) = pyisinstance(o, mpf) ? BigFloat : pyisinstance(o, mpc) ? Complex{BigFloat} : Union{}
 
 #########################################################################
-# BigInt conversion to Python "long" integers
+# Int128 and BigInt conversion to Python "long" integers
 
-function PyObject(i::BigInt)
+function PyObject(i::Union{Int128,BigInt})
     PyObject(@pycheckn ccall((@pysym :PyLong_FromString), PyPtr,
                              (Ptr{UInt8}, Ptr{Void}, Cint),
                              String(string(i)), C_NULL, 10))

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -663,6 +663,15 @@ end
 
 convert(::Type{BigInt}, o::PyObject) = parse(BigInt, pystr(o))
 
+# If 32-bit systems are used, Int64 has to be converted to long integes as well.
+@static if Int == Int32
+    function PyObject(i::Int64)
+        PyObject(@pycheckn ccall((@pysym :PyLong_FromString), PyPtr,
+                                 (Ptr{UInt8}, Ptr{Void}, Cint),
+                                 String(string(i)), C_NULL, 10))
+    end
+end
+
 #########################################################################
 # Dates (Calendar time)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -216,6 +216,17 @@ pyanycheck(T, o::PyObject) = isa(convert(PyAny, o), T)
 @test pyanycheck(Complex128, PyVector{PyObject}(PyObject([1.3+1im]))[1])
 @test pyanycheck(Bool, PyVector{PyObject}(PyObject([true]))[1])
 
+# conversions of Int128 and BigInt
+let i = 1234567890123456789 # Int64
+    @test PyObject(i) - i == 0
+end
+let i = 12345678901234567890 # Int128
+    @test PyObject(i) - i == 0
+end
+let i = BigInt(12345678901234567890) # BigInt
+    @test PyObject(i) - i == 0
+end
+
 pymodule_exists(s::AbstractString) = try
     pyimport(s)
     true


### PR DESCRIPTION
Before this PR, `Int128`s could not be converted to `PyObject`s:
```julia
using PyCall

julia> i=12345678901234567890; @show typeof(i); PyObject(i)
typeof(i) = Int128
ERROR: InexactError()
Stacktrace:
 [1] macro expansion at ...(.julia/v0.6/PyCall/src/exception.jl:78 [inlined]
 [2] PyCall.PyObject(::Int128) at .../.julia/v0.6/PyCall/src/conversions.jl:10
```