### PR TITLE
Misc fixes

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -404,7 +404,8 @@ include("numpy.jl")
 # scipy scalar array members, grrr.
 function is_mapping_object(o::PyObject)
     pyisinstance(o, @pyglobalobj :PyDict_Type) ||
-    (pyquery((@pyglobal :PyMapping_Check), o) && ccall((@pysym :PyObject_HasAttrString), Cint, (PyPtr,Ptr{UInt8}), o, "items") == 1)
+    (pyquery((@pyglobal :PyMapping_Check), o) &&
+      ccall((@pysym :PyObject_HasAttrString), Cint, (PyPtr,Ptr{UInt8}), o, "items") == 1)
 end
 
 """
@@ -420,7 +421,7 @@ mutable struct PyDict{K,V,isdict} <: AbstractDict{K,V}
     # isdict = true for python dict, otherwise is a generic Mapping object
 
     function PyDict{K,V,isdict}(o::PyObject) where {K,V,isdict}
-        if o.o != C_NULL && !is_mapping_object(o)
+        if !isdict && o.o != C_NULL && !is_mapping_object(o)
             throw(ArgumentError("only Dict and Mapping objects can be converted to PyDict"))
         end
         return new{K,V,isdict}(o)


### PR DESCRIPTION
* Avoid using exceptions for control flow when a PyObject doesn't have the `"__array_interface__"` attribute. Provides 5-6x speed up for PyAny conversions for heterogenous lists: `@benchmark convert(PyAny, PyObject([1,2,"c"]))`
  * **Was that the only exception that try block was supposed to catch?**
* Avoid double check for isdict in PyDict constructor
* Couple of other minor changes
