### PR TITLE
Add conversion for IPv4/IPv6 types

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -19,6 +19,7 @@ import Base: size, ndims, similar, copy, getindex, setindex!, stride,
        next, filter!, hash, splice!, pop!, ==, isequal, push!,
        append!, insert!, prepend!, unsafe_convert
 import Compat: pushfirst!, popfirst!, firstindex, lastindex
+import Compat.Sockets: IPv4, IPv6
 
 # Python C API is not interrupt-safe.  In principle, we should
 # use sigatomic for every ccall to the Python library, but this

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -710,6 +710,44 @@ include("pydates.jl")
 #pydate_query(o) = Union{}
 
 #########################################################################
+# IP Addresses
+
+const ipaddress = PyNULL()
+function ipaddress_init()
+    if ispynull(ipaddress)
+        copy!(ipaddress, pyimport("ipaddress"))
+    end
+end
+
+function convert(::Type{IPv4}, o::PyObject)
+    ipaddress_init()
+    if pyisinstance(o, ipaddress["IPv4Address"])
+        IPv4(UInt32(o["_ip"]))
+    else
+        throw(ArgumentError("unknown IPv4 type $o"))
+    end
+end
+
+function convert(::Type{IPv6}, o::PyObject)
+    ipaddress_init()
+    if pyisinstance(o, ipaddress["IPv6Address"])
+        IPv6(UInt128(BigInt(o["_ip"])))
+    else
+        throw(ArgumentError("unknown IPv6 type $o"))
+    end
+end
+
+function PyObject(ip::IPv4)
+    ipaddress_init()
+    ipaddress["IPv4Address"](ip.host)
+end
+
+function PyObject(ip::IPv6)
+    ipaddress_init()
+    ipaddress["IPv6Address"](ip.host)
+end
+
+#########################################################################
 # Inferring Julia types at runtime from Python objects:
 #
 # [Note that we sometimes use the PyFoo_Check API and sometimes we use

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using PyCall, Compat
-using Compat.Test, Compat.Dates, Compat.Serialization
+using Compat.Test, Compat.Dates, Compat.Serialization, Compat.Sockets
 
 filter(f, itr) = collect(Iterators.filter(f, itr))
 filter(f, d::AbstractDict) = Base.filter(f, d)
@@ -155,6 +155,12 @@ pymodule_exists(s::AbstractString) = !ispynull(pyimport_e(s))
     @test roundtripeq(Dates.Second, Dates.Second(typemin(Int32)))
     @test roundtripeq(Dates.Day, Dates.Day(999999999)) # max allowed day timedelta
     @test roundtripeq(Dates.Day, Dates.Day(-999999999)) # min allowed day timedelta
+
+    # IP Addresses
+    @test roundtripeq(IPv4("0.0.0.0"))
+    @test roundtripeq(IPv4("255.255.255.255"))
+    @test roundtripeq(IPv6("::"))
+    @test roundtripeq(IPv6("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"))
 
     # fixme: is there any nontrivial showable test we can do?
     @test !showable("text/html", PyObject(1))


### PR DESCRIPTION
Hi,

This adds support for converting between Julia `IPv4`/`IPv6` types and Python `IPv4Address`/`IPv6Address`.

For some reasons I could not cast  `IPv6Address._ip` directly to `UInt128`. As a workaround I did `UInt128(BigInt(o["_ip"]))`.

I don't know if this is useful enough to be included into PyCall, but anyway, here is the code.