### PR TITLE
better handling of scalar conversions, particularly in Python 3

### DIFF
--- a/src/startup.jl
+++ b/src/startup.jl
@@ -103,17 +103,6 @@ else
     const PyString_Size = :PyBytes_Size
     const PyString_Type = :PyBytes_Type
 end
-if hassym(libpy_handle, :PyInt_Type)
-    const PyInt_Type = :PyInt_Type
-    const PyInt_FromSize_t = :PyInt_FromSize_t
-    const PyInt_FromSsize_t = :PyInt_FromSsize_t
-    const PyInt_AsSsize_t = :PyInt_AsSsize_t
-else
-    const PyInt_Type = :PyLong_Type
-    const PyInt_FromSize_t = :PyLong_FromSize_t
-    const PyInt_FromSsize_t = :PyLong_FromSsize_t
-    const PyInt_AsSsize_t = :PyLong_AsSsize_t
-end
 
 # hashes changed from long to intptr_t in Python 3.2
 const Py_hash_t = pyversion < v"3.2" ? Clong : Int

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -479,7 +479,7 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
         @test isa(t, Tuple{PyObject,PyObject})
         @test t == (PyObject(3), PyObject(34))
     end
-    for T in (Tuple{Vararg{PyAny}}, NTuple{2,Int}, Tuple{Int,Int}, Tuple{Vararg{Int}}, Tuple{Int,Vararg{Int}})
+    for T in (Tuple{Vararg{PyAny}}, NTuple{2,PyInt}, Tuple{PyInt,PyInt}, Tuple{Vararg{PyInt}}, Tuple{PyInt,Vararg{PyInt}})
         let t = convert(T, PyObject((3,34)))
             @test isa(t, Tuple{PyInt,PyInt})
             @test t == (3,34)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ pymodule_exists(s::AbstractString) = !ispynull(pyimport_e(s))
         let o = get(pycall(np["array"], PyObject, 1:3), PyObject, 2)
             @test convert(Int32, o) === Int32(3)
             @test convert(Int64, o) === Int64(3)
+            @test convert(Float64, o) === Float64(3)
             @test convert(Complex{Int}, o) === 3+0im
         end
     end
@@ -235,8 +236,13 @@ pymodule_exists(s::AbstractString) = !ispynull(pyimport_e(s))
     let i = 12345678901234567890 # Int128
         @test PyObject(i) - i == 0
     end
-    let i = BigInt(12345678901234567890) # BigInt
-        @test PyObject(i) - i == 0
+    let i = BigInt(12345678901234567890), o = PyObject(i) # BigInt
+        @test o - i == 0
+        @test BigInt(o) == i
+        if pyversion >= v"3.2"
+            @test PyAny(o) == i == convert(Integer, o)
+            @test_throws InexactError Int64(o)
+        end
     end
 
     # bigfloat conversion

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -563,7 +563,7 @@ end
     @test d[:x] == 5
     d[:x2] = 30
     @test d[:x] == 15
-    @test d[:type_str](10) == string(Int)
+    @test d[:type_str](10) == string(PyInt)
     @test PyCall.builtin[:isinstance](d, PyCall.builtin[:AssertionError])
 
     @test_throws ErrorException @pywith IgnoreError(false) error()


### PR DESCRIPTION
Fixes #510: make sure integer conversions call the `__int__` method in Python 3.   Also use `long long` conversions with overflow checking in Python 3, and fix automatic `BigInt` conversion in Python 3.2 or later.

Better fix for #481: we don't need to call the `.item` field of NumPy scalar types in Python 3 as long as we use a conversion that calls the `__int__`, `__float__`, or `__complex__` methods.