### PR TITLE
Update to 0.7- iteration protocol (start/next/done -> iterate)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
     - osx
 julia:
     - 0.6
+    - 0.7
     - nightly
 addons:
   apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,43 @@ environment:
     PYTHONDIR: "use_conda"
     PYTHON: "Conda"
 
+# Julia 0.7
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+    PYTHONDIR: "C:\\Python27"
+    PYTHON: "C:\\Python27\\python.exe"
+
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+    PYTHONDIR: "C:\\Python33"
+    PYTHON: "C:\\Python33\\python.exe"
+
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+    PYTHONDIR: "C:\\Python34"
+    PYTHON: "C:\\Python34\\python.exe"
+
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+    PYTHONDIR: "use_conda"
+    PYTHON: "Conda"
+
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+    PYTHONDIR: "C:\\Python27-x64"
+    PYTHON: "C:\\Python27-x64\\python.exe"
+
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+    PYTHONDIR: "C:\\Python33-x64"
+    PYTHON: "C:\\Python33-x64\\python.exe"
+
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+    PYTHONDIR: "C:\\Python34-x64"
+    PYTHON: "C:\\Python34-x64\\python.exe"
+
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+    PYTHONDIR: "C:\\Python36-x64"
+    PYTHON: "C:\\Python36-x64\\python.exe"
+
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+    PYTHONDIR: "use_conda"
+    PYTHON: "Conda"
+
 # Nightlies
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
     PYTHONDIR: "C:\\Python27"

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -536,29 +536,59 @@ struct PyDict_Iterator
     i::Int # current position in items list (0-based)
     len::Int # length of items list
 end
-start(d::PyDict{K,V,true}) where {K,V} = PyDict_Iterator(Ref{PyPtr}(), Ref{PyPtr}(), Ref(0), 0, length(d))
-done(d::PyDict{K,V,true}, itr::PyDict_Iterator) where {K,V} = itr.i >= itr.len
-function next(d::PyDict{K,V,true}, itr::PyDict_Iterator) where {K,V}
-    if 0 == ccall((@pysym :PyDict_Next), Cint,
-                  (PyPtr, Ref{Int}, Ref{PyPtr}, Ref{PyPtr}),
-                  d, itr.pa, itr.ka, itr.va)
-        error("unexpected end of PyDict_Next")
-    end
-    ko = pyincref(itr.ka[]) # PyDict_Next returns
-    vo = pyincref(itr.va[]) #   borrowed ref, so incref
-    (Pair(convert(K,ko), convert(V,vo)),
-     PyDict_Iterator(itr.ka, itr.va, itr.pa, itr.i+1, itr.len))
- end
+@static if VERSION < v"0.7.0-DEV.5126" # julia#25261
+    Base.start(d::PyDict{K,V,true}) where {K,V} = PyDict_Iterator(Ref{PyPtr}(), Ref{PyPtr}(), Ref(0), 0, length(d))
+    Base.done(d::PyDict{K,V,true}, itr::PyDict_Iterator) where {K,V} = itr.i >= itr.len
+    function Base.next(d::PyDict{K,V,true}, itr::PyDict_Iterator) where {K,V}
+        if 0 == ccall((@pysym :PyDict_Next), Cint,
+                      (PyPtr, Ref{Int}, Ref{PyPtr}, Ref{PyPtr}),
+                      d, itr.pa, itr.ka, itr.va)
+            error("unexpected end of PyDict_Next")
+        end
+        ko = pyincref(itr.ka[]) # PyDict_Next returns
+        vo = pyincref(itr.va[]) #   borrowed ref, so incref
+        (Pair(convert(K,ko), convert(V,vo)),
+         PyDict_Iterator(itr.ka, itr.va, itr.pa, itr.i+1, itr.len))
+     end
 
-# Iterator for generic mapping, using Python items iterator.
-# To strictly use the Julia iteration protocol, we should pass
-# d.o["items"] rather than d.o to done and next, but the PyObject
-# iterator functions only look at the state s, so we are okay.
-start(d::PyDict{K,V,false}) where {K,V} = start(pycall(d.o["items"], PyObject))
-done(d::PyDict{K,V,false}, s) where {K,V} = done(d.o, s)
-function next(d::PyDict{K,V,false}, s) where {K,V}
-    nxt = PyObject(@pycheck ccall((@pysym :PyIter_Next), PyPtr, (PyPtr,), s[2]))
-    return (convert(Pair{K,V}, s[1]), (nxt, s[2]))
+    # Iterator for generic mapping, using Python items iterator.
+    # To strictly use the Julia iteration protocol, we should pass
+    # d.o["items"] rather than d.o to done and next, but the PyObject
+    # iterator functions only look at the state s, so we are okay.
+    Base.start(d::PyDict{K,V,false}) where {K,V} = start(pycall(d.o["items"], PyObject))
+    Base.done(d::PyDict{K,V,false}, s) where {K,V} = done(d.o, s)
+    function Base.next(d::PyDict{K,V,false}, s) where {K,V}
+        nxt = PyObject(@pycheck ccall((@pysym :PyIter_Next), PyPtr, (PyPtr,), s[2]))
+        return (convert(Pair{K,V}, s[1]), (nxt, s[2]))
+    end
+else
+    function Base.iterate(d::PyDict{K,V,true}, itr=PyDict_Iterator(Ref{PyPtr}(), Ref{PyPtr}(), Ref(0), 0, length(d))) where {K,V}
+        itr.i >= itr.len && return nothing
+        if 0 == ccall((@pysym :PyDict_Next), Cint,
+                      (PyPtr, Ref{Int}, Ref{PyPtr}, Ref{PyPtr}),
+                      d, itr.pa, itr.ka, itr.va)
+            error("unexpected end of PyDict_Next")
+        end
+        ko = pyincref(itr.ka[]) # PyDict_Next returns
+        vo = pyincref(itr.va[]) #   borrowed ref, so incref
+        (Pair(convert(K,ko), convert(V,vo)),
+         PyDict_Iterator(itr.ka, itr.va, itr.pa, itr.i+1, itr.len))
+    end
+
+    # Iterator for generic mapping, using Python items iterator.
+    # Our approach is to wrap an iterator over d.o["items"]
+    # which necessitates including d.o["items"] in the state.
+    function _start(d::PyDict{K,V,false}) where {K,V}
+        d_items = pycall(d.o["items"], PyObject)
+        (d_items, iterate(d_items))
+    end
+    function Base.iterate(d::PyDict{K,V,false}, itr=_start(d)) where {K,V}
+        d_items, iter_result = itr
+        iter_result === nothing && return nothing
+        item, state = iter_result
+        iter_result = iterate(d_items, state)
+        (item[1] => item[2], (d_items, iter_result))
+    end
 end
 
 #########################################################################


### PR DESCRIPTION
I've spent the past week hoping that someone better versed in the new iteration protocol than me might take a crack at this, but at least the tests pass.

The remaining deprecation warnings  in `pkg> test PyCall` (see below) are mostly related to implicit conversion/construction of `Number` types; it's not quite the same issue but I'll wait for the resolution of https://github.com/JuliaDiff/ForwardDiff.jl/pull/342 before defining
```julia
(::Type{T})(x::PyObject) where {T<:Number} = convert(T, x)
```
or at the very least,
```julia
(::Type{T})(x::PyObject) where {T<:Integer} = convert(T, x)
```
---
```julia
┌ Info: Python version 3.6.5 from libpython3.6m, PYTHONHOME=/usr:/usr
│ ENV[PYTHONPATH]=/opt/ros/melodic/lib/python2.7/dist-packages:/home/schmrlng/catkin_ws/devel/lib/python2.7/dist-packages
│ ENV[PYTHONHOME]=
└ ENV[PYTHONEXECUTABLE]=
┌ Warning: Constructors no longer fall back to `convert`. A constructor `BigInt(::PyObject)` should be defined instead.
│   caller = top-level scope at runtests.jl:237
└ @ Core ~/.julia/dev/PyCall/test/runtests.jl:237
┌ Warning: Constructors no longer fall back to `convert`. A constructor `Int64(::PyObject)` should be defined instead.
│   caller = top-level scope at runtests.jl:242
└ @ Core ~/.julia/dev/PyCall/test/runtests.jl:242
┌ Warning: InexactError now supports arguments, use `InexactError(funcname::Symbol, ::Type, value)` instead.
│   caller = ip:0x0
└ @ Core :-1
┌ Warning: Constructors no longer fall back to `convert`. A constructor `Int64(::PyObject)` should be defined instead.
│   caller = top-level scope at runtests.jl:308
└ @ Core ~/.julia/dev/PyCall/test/runtests.jl:308
┌ Warning: Constructors no longer fall back to `convert`. A constructor `Int64(::PyObject)` should be defined instead.
│   caller = top-level scope at runtests.jl:308
└ @ Core ~/.julia/dev/PyCall/test/runtests.jl:308
Test Summary: | Pass  Total
PyCall        |  412    412
Test Summary: | Pass  Total
pydef         |    6      6
Test Summary: | Pass  Total
pycall!       |   16     16
   Testing PyCall tests passed
```