### PR TITLE
Make untyped mutating callbacks work

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -151,6 +151,13 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
         @test x == ["bar"]
     end
 
+    py"""
+    def apply(f, *args):
+        f(*args)
+        return args
+    """
+    @test py"apply"(fill!, zeros(3), 10)[1] == [10, 10, 10]
+
     @test roundtripeq(Dates.Date(2012,3,4))
     @test roundtripeq(Dates.DateTime(2012,3,4, 7,8,9,11))
     @test roundtripeq(Dates.Millisecond(typemax(Int32)))


### PR DESCRIPTION
I'm writing this PR to start a discussion: Do we want untyped Julia callback to be able to mutate Python objects?  That is to say, do we want the following code to work?

```julia
py"""
def apply(f, *args):
    f(*args)
    return args
"""
@test py"apply"(fill!, zeros(3), 10)[1] == [10, 10, 10]
```

I got here while trying to fix pyjulia bug I observed in https://github.com/JuliaPy/pyjulia/pull/183#discussion_r211043993

It requires some run-time introspection and hard-coding many mutable Python objects (I only did it for Numpy array at the moment).  Is there a better way to do it?  Do we want this in the first place?