### PR TITLE
Libdl.dlsym_e now returns 'nothing' rather than 'C_NULL' when a symbo…

### DIFF
--- a/deps/depsutils.jl
+++ b/deps/depsutils.jl
@@ -1,6 +1,6 @@
 import Compat.Libdl
 
-hassym(lib, sym) = Libdl.dlsym_e(lib, sym) != C_NULL
+hassym(lib, sym) = Libdl.dlsym_e(lib, sym) != nothing
 
 # call dlsym_e on a sequence of symbols and return the symbol that gives
 # the first non-null result


### PR DESCRIPTION
…l is not found.  Updated hassym