### PR TITLE
Don't steal reference from existing Python object

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -133,6 +133,16 @@ function pystealref!(o::PyObject)
     return optr
 end
 
+"""
+    pyreturn(x) :: PyPtr
+
+Prepare `PyPtr` from `x` for passing it to Python.  If `x` is already
+a `PyObject`, the refcount is incremented.  Otherwise a `PyObject`
+wrapping/converted from `x` is created.
+"""
+pyreturn(x::Any) = pystealref!(PyObject(x))
+pyreturn(x::PyObject) = pyincref_(x.o)
+
 function Base.copy!(dest::PyObject, src::PyObject)
     pydecref(dest)
     dest.o = src.o

--- a/src/callback.jl
+++ b/src/callback.jl
@@ -37,11 +37,7 @@ function _pyjlwrap_call(f, args_::PyPtr, kw_::PyPtr)
             ret = Core._apply_latest(f_kw_closure)
         end
 
-        if ret isa PyObject
-            # Don't steal reference from existing Python object (#551)
-            return pyincref_(ret.o)
-        end
-        return pystealref!(PyObject(ret))
+        return pyreturn(ret)
     catch e
         pyraise(e)
     finally

--- a/src/pyiterator.jl
+++ b/src/pyiterator.jl
@@ -65,7 +65,7 @@ const jlWrapIteratorType = PyTypeObject()
             if !done(iter, state)
                 item, state′ = next(iter, state)
                 stateref[] = state′ # stores new state in the iterator object
-                return pystealref!(PyObject(item))
+                return pyreturn(item)
             end
         catch e
             pyraise(e)
@@ -80,7 +80,7 @@ else
             if iter_result !== nothing
                 item, state = iter_result
                 iter_result_ref[] = iterate(iter, state)
-                return pystealref!(PyObject(item))
+                return pyreturn(item)
             end
         catch e
             pyraise(e)

--- a/src/pytype.jl
+++ b/src/pytype.jl
@@ -377,7 +377,7 @@ function pyjlwrap_getattr(self_::PyPtr, attr__::PyPtr)
         else
             fidx = Base.fieldindex(typeof(f), Symbol(attr), false)
             if fidx != 0
-                return pystealref!(PyObject(getfield(f, fidx)))
+                return pyreturn(getfield(f, fidx))
             else
                 return ccall(@pysym(:PyObject_GenericGetAttr), PyPtr, (PyPtr,PyPtr), self_, attr__)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -589,6 +589,24 @@ end
     """
     py"set"("obj")
     @test anonymous.obj != PyNULL()
+
+    # Test above for pyjlwrap_getattr too:
+    anonymous = Module()
+    Base.eval(
+        anonymous, quote
+            using PyCall
+            struct S
+                x
+            end
+            obj = S(pyimport("sys"))
+        end)
+    py"""
+    ns = {}
+    def set(name):
+        ns[name] = $include_string($anonymous, name).x
+    """
+    py"set"("obj")
+    @test anonymous.obj.x != PyNULL()
 end
 
 include("test_pyfncall.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -607,6 +607,22 @@ end
     """
     py"set"("obj")
     @test anonymous.obj.x != PyNULL()
+
+    # Test above for pyjlwrap_iternext too:
+    anonymous = Module()
+    Base.eval(
+        anonymous, quote
+            using PyCall
+            sys = pyimport("sys")
+            obj = (sys for _ in 1:1)
+        end)
+    py"""
+    ns = {}
+    def set(name):
+        ns[name] = list(iter($include_string($anonymous, name)))
+    """
+    py"set"("obj")
+    @test anonymous.sys != PyNULL()
 end
 
 include("test_pyfncall.jl")


### PR DESCRIPTION
closes #551

I'm not very familiar with Python C API but I think this fixes the bug.