### PR TITLE
Fix memory leak

### DIFF
--- a/src/pyfncall.jl
+++ b/src/pyfncall.jl
@@ -44,7 +44,7 @@ function __pycall!(ret::PyObject, pyargsptr::PyPtr, o::Union{PyObject,PyPtr},
         retptr = @pycheckn ccall((@pysym :PyObject_Call), PyPtr, (PyPtr,PyPtr,PyPtr), o,
                         pyargsptr, kw)
         pydecref_(ret.o)
-        ret.o = pyincref_(retptr)
+        ret.o = retptr
     finally
         sigatomic_end()
     end


### PR DESCRIPTION
Since `PyObject_Call` returns a new reference, we don't need to increment the reference count.

https://docs.python.org/3/c-api/object.html#c.PyObject_Call

closes #542