### PR TITLE
remove const declaration in `@pydef` which is deprecated in local scope

### DIFF
--- a/src/pyclass.jl
+++ b/src/pyclass.jl
@@ -150,7 +150,7 @@ Multiple dispatch works, too:
 """
 macro pydef(class_expr)
     class_name, _, _ = parse_pydef_toplevel(class_expr)
-    esc(:(const $class_name = $PyCall.@pydef_object($class_expr)))
+    esc(:($class_name = $PyCall.@pydef_object($class_expr)))
 end
 
 """


### PR DESCRIPTION
`@pydef` declares the class `const` which if done in the local scope is deprecated in 0.7 / errors on 1.0. I just removed the `const`. I suppose it could still remain there in the global scope, which would offer slightly better type-stability / performance, but if you're building / calling into a Python class I would argue the overhead is likely to be insignificant in most cases. 