### PR TITLE
Re-enable SIGINT handler in pyjlwrap_call

### DIFF
--- a/src/callback.jl
+++ b/src/callback.jl
@@ -47,7 +47,9 @@ function _pyjlwrap_call(f, args_::PyPtr, kw_::PyPtr)
 end
 
 pyjlwrap_call(self_::PyPtr, args_::PyPtr, kw_::PyPtr) =
-    _pyjlwrap_call(unsafe_pyjlwrap_to_objref(self_), args_, kw_)
+    reenable_sigint() do
+        _pyjlwrap_call(unsafe_pyjlwrap_to_objref(self_), args_, kw_)
+    end
 
 ################################################################
 # allow the user to convert a Julia function into a Python


### PR DESCRIPTION
This PR makes the following example work:

```julia
julia> py"""
       try:
           print("Hit Ctrl-C a few seconds later!")
           $sleep(10)
       except KeyboardInterrupt as err:
           print("Got:", err)
       else:
           print("Got nothing")
       """
Hit Ctrl-C a few seconds later!
^CGot: Julia exception: InterruptException()
```

Without this PR, the exception is raised in Julia side after the `sleep` is completed (i.e., no early termination):

```julia

julia> py"""
       try:
           print("Hit Ctrl-C a few seconds later!")
           $sleep(10)
       except KeyboardInterrupt as err:
           print("Got:", err)
       else:
           print("Got nothing")
       """
Hit Ctrl-C a few seconds later!
^CGot nothing
ERROR: InterruptException:
```
