### PR TITLE
Support virtual environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: julia
+dist: trusty  # update "python3.4-venv" below when updating
 os:
     - linux
     - osx
@@ -11,6 +12,7 @@ addons:
     packages:
       - python-numpy
       - python3-numpy
+      - python3.4-venv  # Ubuntu Trusty 14.04 does not have python3-venv
 env:
   global:
     - PYCALL_DEBUG_BUILD="yes"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ then be aware that PyCall *uses the virtualenv it was built with* by
 default, even if you switch virtualenvs.  If you want to switch PyCall
 to use a different virtualenv, then you should switch virtualenvs and
 run `rm(Pkg.dir("PyCall","deps","PYTHON")); Pkg.build("PyCall")`.
-Alternatively, see [Python virtual environment](#python-virtual-environment)
+Alternatively, see [Python virtual environments](#python-virtual-environments)
 section below for switching virtual environment at run-time.
 
 **Note:** Usually, the necessary libraries are installed along with
@@ -545,17 +545,17 @@ and so on.
 Here, instead of `pyimport`, we have used the function `pyimport_conda`.   The second argument is the name of the [Anaconda package](https://docs.continuum.io/anaconda/pkg-docs) that provides this module.   This way, if importing `scipy.optimize` fails because the user hasn't installed `scipy`, it will either (a) automatically install `scipy` and retry the `pyimport` if PyCall is configured to use the [Conda](https://github.com/Luthaf/Conda.jl) Python install (or
 any other Anaconda-based Python distro for which the user has installation privileges), or (b) throw an error explaining that `scipy` needs to be installed, and explain how to configure PyCall to use Conda so that it can be installed automatically.   More generally, you can call `pyimport(module, package, channel)` to specify an optional Anaconda "channel" for installing non-standard Anaconda packages.
 
-## Python virtual environment
+## Python virtual environments
 
-Python's virtual environment created by [`venv`] and [`virtualenv`]
+Python virtual environments created by [`venv`] and [`virtualenv`]
 can be used from `PyCall`, *provided that the Python executable used
 in the virtual environment is linked against the same `libpython` used
-by `PyCall`*.  Note that virtual environment created by `conda` is not
+by `PyCall`*.  Note that virtual environments created by `conda` are not
 supported.
 
-To use `PyCall` with a certain virtual environment, set environment
+To use `PyCall` with a certain virtual environment, set the environment
 variable `PYCALL_JL_RUNTIME_PYTHON` *before* importing `PyCall` to
-path to the Python executable.  Example:
+path to the Python executable.  For example:
 
 ```julia
 $ source PATH/TO/bin/activate  # activate virtual environment in system shell
@@ -571,10 +571,7 @@ julia> using PyCall
 julia> pyimport("sys").executable
 "PATH/TO/bin/python3"
 ```
-
-This feature works by calling [`Py_SetProgramName`] with the value
-specified by `PYCALL_JL_RUNTIME_PYTHON`.  Similarly, the path passed
-to [`Py_SetPythonHome`] can be controlled by environment variable
+Similarly, the `PYTHONHOME` path can be changed by the environment variable
 `PYCALL_JL_RUNTIME_PYTHONHOME`.
 
 [`venv`]: https://docs.python.org/3/library/venv.html

--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ any other Anaconda-based Python distro for which the user has installation privi
 
 ## Python virtual environments
 
-Python virtual environments created by [`venv`] and [`virtualenv`]
+Python virtual environments created by [`venv`](https://docs.python.org/3/library/venv.html) and [`virtualenv`](https://virtualenv.pypa.io/en/latest/)
 can be used from `PyCall`, *provided that the Python executable used
 in the virtual environment is linked against the same `libpython` used
 by `PyCall`*.  Note that virtual environments created by `conda` are not
@@ -573,11 +573,6 @@ julia> pyimport("sys").executable
 ```
 Similarly, the `PYTHONHOME` path can be changed by the environment variable
 `PYCALL_JL_RUNTIME_PYTHONHOME`.
-
-[`venv`]: https://docs.python.org/3/library/venv.html
-[`virtualenv`]: https://virtualenv.pypa.io/en/latest/
-[`Py_SetProgramName`]: https://docs.python.org/3/c-api/init.html#c.Py_SetProgramName
-[`Py_SetPythonHome`]: https://docs.python.org/3/c-api/init.html#c.Py_SetPythonHome
 
 ## Author
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -92,11 +92,6 @@ include("depsutils.jl")
 
 #########################################################################
 
-# A couple of key strings need to be stored as constants so that
-# they persist throughout the life of the program.  In Python 3,
-# they need to be wchar_t* data.
-wstringconst(s) = string("Base.cconvert(Cwstring, \"", escape_string(s), "\")")
-
 # we write configuration files only if they change, both
 # to prevent unnecessary recompilation and to minimize
 # problems in the unlikely event of read-only directories.
@@ -190,10 +185,8 @@ try # make sure deps.jl file is removed on error
     const python = "$(escape_string(python))"
     const libpython = "$(escape_string(libpy_name))"
     const pyprogramname = "$(escape_string(programname))"
-    const wpyprogramname = $(wstringconst(programname))
     const pyversion_build = $(repr(pyversion))
     const PYTHONHOME = "$(escape_string(PYTHONHOME))"
-    const wPYTHONHOME = $(wstringconst(PYTHONHOME))
 
     "True if we are using the Python distribution in the Conda package."
     const conda = $use_conda

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,28 +12,6 @@ struct UseCondaPython <: Exception end
 
 #########################################################################
 
-# Fix the environment for running `python`, and setts IO encoding to UTF-8.
-# If cmd is the Conda python, then additionally removes all PYTHON* and
-# CONDA* environment variables.
-function pythonenv(cmd::Cmd)
-    env = copy(ENV)
-    if dirname(cmd.exec[1]) == abspath(Conda.PYTHONDIR)
-        pythonvars = String[]
-        for var in keys(env)
-            if startswith(var, "CONDA") || startswith(var, "PYTHON")
-                push!(pythonvars, var)
-            end
-        end
-        for var in pythonvars
-            pop!(env, var)
-        end
-    end
-    # set PYTHONIOENCODING when running python executable, so that
-    # we get UTF-8 encoded text as output (this is not the default on Windows).
-    env["PYTHONIOENCODING"] = "UTF-8"
-    setenv(cmd, env)
-end
-
 pyvar(python::AbstractString, mod::AbstractString, var::AbstractString) = chomp(read(pythonenv(`$python -c "import $mod; print($mod.$var)"`), String))
 
 pyconfigvar(python::AbstractString, var::AbstractString) = pyvar(python, "distutils.sysconfig", "get_config_var('$var')")
@@ -194,15 +172,7 @@ try # make sure deps.jl file is removed on error
     # Get PYTHONHOME, either from the environment or from Python
     # itself (if it is not in the environment or if we are using Conda)
     PYTHONHOME = if !haskey(ENV, "PYTHONHOME") || use_conda
-        # PYTHONHOME tells python where to look for both pure python
-        # and binary modules.  When it is set, it replaces both
-        # `prefix` and `exec_prefix` and we thus need to set it to
-        # both in case they differ. This is also what the
-        # documentation recommends.  However, they are documented
-        # to always be the same on Windows, where it causes
-        # problems if we try to include both.
-        exec_prefix = pysys(python, "exec_prefix")
-        Compat.Sys.iswindows() ? exec_prefix : pysys(python, "prefix") * ":" * exec_prefix
+        pythonhome_of(python)
     else
         ENV["PYTHONHOME"]
     end

--- a/deps/depsutils.jl
+++ b/deps/depsutils.jl
@@ -31,3 +31,86 @@ end
 
 # need to be able to get the version before Python is initialized
 Py_GetVersion(libpy) = unsafe_string(ccall(Libdl.dlsym(libpy, :Py_GetVersion), Ptr{UInt8}, ()))
+
+# Fix the environment for running `python`, and setts IO encoding to UTF-8.
+# If cmd is the Conda python, then additionally removes all PYTHON* and
+# CONDA* environment variables.
+function pythonenv(cmd::Cmd)
+    env = copy(ENV)
+    if dirname(cmd.exec[1]) == abspath(Conda.PYTHONDIR)
+        pythonvars = String[]
+        for var in keys(env)
+            if startswith(var, "CONDA") || startswith(var, "PYTHON")
+                push!(pythonvars, var)
+            end
+        end
+        for var in pythonvars
+            pop!(env, var)
+        end
+    end
+    # set PYTHONIOENCODING when running python executable, so that
+    # we get UTF-8 encoded text as output (this is not the default on Windows).
+    env["PYTHONIOENCODING"] = "UTF-8"
+    setenv(cmd, env)
+end
+
+
+function pythonhome_of(pyprogramname::AbstractString)
+    if Compat.Sys.iswindows()
+        # PYTHONHOME tells python where to look for both pure python
+        # and binary modules.  When it is set, it replaces both
+        # `prefix` and `exec_prefix` and we thus need to set it to
+        # both in case they differ. This is also what the
+        # documentation recommends.  However, they are documented
+        # to always be the same on Windows, where it causes
+        # problems if we try to include both.
+        script = """
+        import sys
+        if hasattr(sys, "base_exec_prefix"):
+            sys.stdout.write(sys.base_exec_prefix)
+        else:
+            sys.stdout.write(sys.exec_prefix)
+        """
+    else
+        script = """
+        import sys
+        if hasattr(sys, "base_exec_prefix"):
+            sys.stdout.write(sys.base_prefix)
+            sys.stdout.write(":")
+            sys.stdout.write(sys.base_exec_prefix)
+        else:
+            sys.stdout.write(sys.prefix)
+            sys.stdout.write(":")
+            sys.stdout.write(sys.exec_prefix)
+        """
+        # https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHOME
+    end
+    return read(pythonenv(`$pyprogramname -c $script`), String)
+end
+# To support `venv` standard library (as well as `virtualenv`), we
+# need to use `sys.base_prefix` and `sys.base_exec_prefix` here.
+# Otherwise, initializing Python in `__init__` below fails with
+# unrecoverable error:
+#
+#   Fatal Python error: initfsencoding: unable to load the file system codec
+#   ModuleNotFoundError: No module named 'encodings'
+#
+# This is because `venv` does not symlink standard libraries like
+# `virtualenv`.  For example, `lib/python3.X/encodings` does not
+# exist.  Rather, `venv` relies on the behavior of Python runtime:
+#
+#   If a file named "pyvenv.cfg" exists one directory above
+#   sys.executable, sys.prefix and sys.exec_prefix are set to that
+#   directory and it is also checked for site-packages
+#   --- https://docs.python.org/3/library/venv.html
+#
+# Thus, we need point `PYTHONHOME` to `sys.base_prefix` and
+# `sys.base_exec_prefix`.  If the virtual environment is created by
+# `virtualenv`, those `sys.base_*` paths point to the virtual
+# environment.  Thus, above code supports both use cases.
+#
+# See also:
+# * https://docs.python.org/3/library/venv.html
+# * https://docs.python.org/3/library/site.html
+# * https://docs.python.org/3/library/sys.html#sys.base_exec_prefix
+# * https://github.com/JuliaPy/PyCall.jl/issues/410

--- a/deps/depsutils.jl
+++ b/deps/depsutils.jl
@@ -50,7 +50,9 @@ end
 """
     _preserveas!(dest::Vector{UInt8}, (Cstring|Cwstring), x::String) :: Ptr
 
-Copy `x` as `Cstring` or `Cwstring` to `dest`.
+Copy `x` as `Cstring` or `Cwstring` to `dest` and return a pointer to
+`dest`.  Thus, this pointer is safe to use as long as `dest` is
+protected from GC.
 """
 function _preserveas!(dest::Vector{UInt8}, ::Type{Cstring}, x::AbstractString)
     s = transcode(UInt8, String(x))

--- a/deps/depsutils.jl
+++ b/deps/depsutils.jl
@@ -61,7 +61,7 @@ end
 
 function _preserveas!(dest::Vector{UInt8}, ::Type{Cwstring}, x::AbstractString)
     s = Base.cconvert(Cwstring, x)
-    copyto!(reinterpret(Int32, dest), s)
+    copyto!(dest, reinterpret(UInt8, s))
     return pointer(dest)
 end
 

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -36,6 +36,12 @@ import Base.Iterators: filter
 include(joinpath(dirname(@__FILE__), "..", "deps","depsutils.jl"))
 include("startup.jl")
 
+"""
+Python executable used by PyCall in the current process.
+"""
+current_python() = _current_python[]
+const _current_python = Ref(pyprogramname)
+
 #########################################################################
 
 # Mirror of C PyObject struct (for non-debugging Python builds).
@@ -461,7 +467,7 @@ you want to use, run Pkg.build("PyCall"), and re-launch Julia.
                     msg = msg * """
 PyCall is currently configured to use the Python version at:
 
-$python
+$(current_python())
 
 and you should use whatever mechanism you usually use (apt-get, pip, conda,
 etcetera) to install the Python package containing the $name module.

--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -91,7 +91,7 @@ _leak(::Type{Cwstring}, x::AbstractString) =
     _leak(Base.cconvert(Cwstring, x))
 
 function pythonhome_of(pyprogramname::AbstractString)
-    if Sys.iswindows()
+    if Compat.Sys.iswindows()
         script = """
         import sys
         sys.stdout.write(sys.exec_prefix)

--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -66,13 +66,15 @@ end
 venv_python(::Nothing) = pyprogramname
 
 function venv_python(venv::AbstractString, suffix::AbstractString = "")
-    # See:
-    # https://github.com/python/cpython/blob/3.7/Lib/venv/__init__.py#L116
+    # `suffix` is used to insert version number (e.g., "3.7") in tests
+    # (see ../test/test_venv.jl)
     if Compat.Sys.iswindows()
         return joinpath(venv, "Scripts", "python$suffix.exe")
     else
         return joinpath(venv, "bin", "python$suffix")
     end
+    # "Scripts" is used only in Windows and "bin" elsewhere:
+    # https://github.com/python/cpython/blob/3.7/Lib/venv/__init__.py#L116
 end
 
 """

--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -92,13 +92,13 @@ _leak(::Type{Cwstring}, x::AbstractString) =
 
 venv_python(::Nothing) = pyprogramname
 
-function venv_python(venv::AbstractString)
+function venv_python(venv::AbstractString, suffix::AbstractString = "")
     # See:
     # https://github.com/python/cpython/blob/3.7/Lib/venv/__init__.py#L116
     if Compat.Sys.iswindows()
-        return joinpath(venv, "Scripts", "python.exe")
+        return joinpath(venv, "Scripts", "python$suffix.exe")
     else
-        return joinpath(venv, "bin", "python")
+        return joinpath(venv, "bin", "python$suffix")
     end
 end
 

--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -149,19 +149,19 @@ function __init__()
     if already_inited
         # Importing from PyJulia takes this path.
     elseif isfile(get(ENV, "PYCALL_JL_RUNTIME_PYTHON", ""))
-        venv_python = ENV["PYCALL_JL_RUNTIME_PYTHON"]
+        _current_python[] = ENV["PYCALL_JL_RUNTIME_PYTHON"]
 
         # Check libpython compatibility.
-        venv_libpython = find_libpython(venv_python)
+        venv_libpython = find_libpython(current_python())
         if venv_libpython === nothing
             error("""
-            `libpython` for $venv_python cannot be found.
+            `libpython` for $(current_python()) cannot be found.
             PyCall.jl cannot initialize Python safely.
             """)
         elseif venv_libpython != libpython
             error("""
             Incompatible `libpython` detected.
-            `libpython` for $venv_python is:
+            `libpython` for $(current_python()) is:
                 $venv_libpython
             `libpython` for $pyprogramname is:
                 $libpython
@@ -173,18 +173,18 @@ function __init__()
         if haskey(ENV, "PYCALL_JL_RUNTIME_PYTHONHOME")
             venv_home = ENV["PYCALL_JL_RUNTIME_PYTHONHOME"]
         else
-            venv_home = pythonhome_of(venv_python)
+            venv_home = pythonhome_of(current_python())
         end
         if pyversion.major < 3
             ccall((@pysym :Py_SetPythonHome), Cvoid, (Cstring,),
                   _leak(Cstring, venv_home))
             ccall((@pysym :Py_SetProgramName), Cvoid, (Cstring,),
-                  _leak(Cstring, venv_python))
+                  _leak(Cstring, current_python()))
         else
             ccall((@pysym :Py_SetPythonHome), Cvoid, (Ptr{Cwchar_t},),
                   _leak(Cwstring, venv_home))
             ccall((@pysym :Py_SetProgramName), Cvoid, (Ptr{Cwchar_t},),
-                  _leak(Cwstring, venv_python))
+                  _leak(Cwstring, current_python()))
         end
         ccall((@pysym :Py_InitializeEx), Cvoid, (Cint,), 0)
     else

--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -110,13 +110,28 @@ function pythonhome_of(pyprogramname::AbstractString)
 end
 
 """
-    python_cmd(args::Cmd = ``) :: Cmd
+    python_cmd(args::Cmd = ``; venv) :: Cmd
 
 Create an appropriate `Cmd` for running Python program with command
 line arguments `args`.
+
+# Keyword Arguments
+- `venv::String`: The path of a virtualenv to be used instead of the
+  default environment with which PyCall isconfigured.
 """
-function python_cmd(args::Cmd = ``)
-    cmd = `$pyprogramname $args`
+function python_cmd(args::Cmd = ``; venv::Union{Nothing, String} = nothing)
+    if venv == nothing
+        py = pyprogramname
+    else
+        # See:
+        # https://github.com/python/cpython/blob/3.7/Lib/venv/__init__.py#L116
+        if Compat.Sys.iswindows()
+            py = joinpath(venv, "Scripts", "python.exe")
+        else
+            py = joinpath(venv, "bin", "python")
+        end
+    end
+    cmd = `$py $args`
 
     # For Windows:
     env = copy(ENV)

--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -106,14 +106,22 @@ function pythonhome_of(pyprogramname::AbstractString)
         """
         # https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHOME
     end
-    cmd = `$pyprogramname -c $script`
+    return read(python_cmd(`-c $script`), String)
+end
+
+"""
+    python_cmd(args::Cmd = ``) :: Cmd
+
+Create an appropriate `Cmd` for running Python program with command
+line arguments `args`.
+"""
+function python_cmd(args::Cmd = ``)
+    cmd = `$pyprogramname $args`
 
     # For Windows:
     env = copy(ENV)
     env["PYTHONIOENCODING"] = "UTF-8"
-    cmd = setenv(cmd, env)
-
-    return read(cmd, String)
+    return setenv(cmd, env)
 end
 
 function find_libpython(python::AbstractString)

--- a/src/startup.jl
+++ b/src/startup.jl
@@ -46,7 +46,7 @@ if !symbols_present
     # Only to be used at top-level - pointer will be invalid after reload
     libpy_handle = Libdl.dlopen(libpython, Libdl.RTLD_LAZY|Libdl.RTLD_DEEPBIND|Libdl.RTLD_GLOBAL)
     # need SetPythonHome to avoid warning, #299
-    Py_SetPythonHome(libpy_handle, PYTHONHOME, wPYTHONHOME, pyversion_build)
+    Py_SetPythonHome(libpy_handle, pyversion_build, PYTHONHOME)
 else
     @static if Compat.Sys.iswindows()
         pathbuf = Vector{UInt16}(undef, 1024)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -667,3 +667,4 @@ def try_call(f):
 end
 
 include("test_pyfncall.jl")
+include("test_venv.jl")

--- a/test/test_venv.jl
+++ b/test/test_venv.jl
@@ -63,7 +63,8 @@ end
     elseif Compat.Sys.which(pyname) === nothing
         @info "No $pyname command. Skipping the test..."
     else
-        mktempdir() do path
+        mktempdir() do tmppath
+            path = joinpath(tmppath, "ϵνιℓ")
             run(`virtualenv --python=$pyname $path`)
             test_venv_has_python(path)
 
@@ -109,7 +110,8 @@ end
     elseif !success(PyCall.python_cmd(`-c "import venv"`, python=python))
         @info "Skip venv test since venv package is missing."
     else
-        mktempdir() do path
+        mktempdir() do tmppath
+            path = joinpath(tmppath, "ϵνιℓ")
             # Create a new virtual environment
             run(PyCall.python_cmd(`-m venv $path`, python=python))
             test_venv_has_python(path)

--- a/test/test_venv.jl
+++ b/test/test_venv.jl
@@ -2,31 +2,6 @@ using PyCall, Compat, Compat.Test
 using Compat: @info, @warn
 
 
-@testset "fuzz PyCall._leak" begin
-    N = 10000
-
-    @testset "_leak(Cstring, ...)" begin
-        for i in 1:N
-            x = String(rand('A':'z', rand(1:1000)))
-            y = Base.unsafe_string(PyCall._leak(Cstring, x))
-            @test x == y
-        end
-    end
-
-    @testset "_leak(Cwstring, ...)" begin
-        for i in 1:N
-            x = String(rand('A':'z', rand(1:1000)))
-            a = Base.cconvert(Cwstring, x)
-            ptr = PyCall._leak(a)
-            z = unsafe_wrap(Array, ptr, size(a))
-            @test z[end] == 0
-            y = transcode(String, z)[1:end-1]
-            @test x == y
-        end
-    end
-end
-
-
 function test_venv_has_python(path)
     newpython = PyCall.python_cmd(venv=path).exec[1]
     if !isfile(newpython)

--- a/test/test_venv.jl
+++ b/test/test_venv.jl
@@ -36,9 +36,13 @@ end
         mktempdir() do path
             # Create a new virtualenv
             run(PyCall.python_cmd(`-m venv $path`))
-            newpython = joinpath(path, "bin", "python")
-            if Compat.Sys.iswindows()
-                newpython *= ".exe"
+            newpython = PyCall.python_cmd(venv=path).exec[1]
+            if !isfile(newpython)
+                @info """
+                Python executable $newpython does not exists.
+                This directory contains only the following files:
+                $(join(readdir(dirname(newpython)), '\n'))
+                """
             end
             @test isfile(newpython)
 

--- a/test/test_venv.jl
+++ b/test/test_venv.jl
@@ -1,0 +1,63 @@
+using PyCall, Compat, Compat.Test
+using Compat: @info
+
+
+@testset "fuzz PyCall._leak" begin
+    N = 10000
+
+    @testset "_leak(Cstring, ...)" begin
+        for i in 1:N
+            x = String(rand('A':'z', rand(1:1000)))
+            y = Base.unsafe_string(PyCall._leak(Cstring, x))
+            @test x == y
+        end
+    end
+
+    @testset "_leak(Cwstring, ...)" begin
+        for i in 1:N
+            x = String(rand('A':'z', rand(1:1000)))
+            a = Base.cconvert(Cwstring, x)
+            ptr = PyCall._leak(a)
+            z = unsafe_wrap(Array, ptr, size(a))
+            @test z[end] == 0
+            y = transcode(String, z)[1:end-1]
+            @test x == y
+        end
+    end
+end
+
+
+@testset "venv activation" begin
+    if PyCall.conda
+        @info "Skip venv test with conda."
+    elseif !success(PyCall.python_cmd(`-c "import venv"`))
+        @info "Skip venv test since venv package is missing."
+    else
+        mktempdir() do path
+            # Create a new virtualenv
+            run(PyCall.python_cmd(`-m venv $path`))
+            newpython = joinpath(path, "bin", "python")
+            if Compat.Sys.iswindows()
+                newpython *= ".exe"
+            end
+            @test isfile(newpython)
+
+            # Run a fresh Julia process with new Python environment
+            if VERSION < v"0.7.0-"
+                setup_code = ""
+            else
+                setup_code = Base.load_path_setup_code()
+            end
+            code = """
+            $setup_code
+            using PyCall
+            print(PyCall.pyimport("sys")[:executable])
+            """
+            env = copy(ENV)
+            env["PYCALL_JL_RUNTIME_PYTHON"] = newpython
+            jlcmd = setenv(`$(Base.julia_cmd()) -e $code`, env)
+            output = read(jlcmd, String)
+            @test newpython == output
+        end
+    end
+end

--- a/test/test_venv.jl
+++ b/test/test_venv.jl
@@ -18,13 +18,8 @@ function test_venv_activation(path)
     newpython = PyCall.python_cmd(venv=path).exec[1]
 
     # Run a fresh Julia process with new Python environment
-    if VERSION < v"0.7.0-"
-        setup_code = ""
-    else
-        setup_code = Base.load_path_setup_code()
-    end
     code = """
-    $setup_code
+    $(Base.load_path_setup_code())
     using PyCall
     println(PyCall.pyimport("sys").executable)
     println(PyCall.pyimport("sys").exec_prefix)

--- a/test/test_venv.jl
+++ b/test/test_venv.jl
@@ -64,7 +64,11 @@ end
         @info "No $pyname command. Skipping the test..."
     else
         mktempdir() do tmppath
-            path = joinpath(tmppath, "ϵνιℓ")
+            if PyCall.pyversion.major == 2
+                path = joinpath(tmppath, "kind")
+            else
+                path = joinpath(tmppath, "ϵνιℓ")
+            end
             run(`virtualenv --python=$pyname $path`)
             test_venv_has_python(path)
 
@@ -111,7 +115,11 @@ end
         @info "Skip venv test since venv package is missing."
     else
         mktempdir() do tmppath
-            path = joinpath(tmppath, "ϵνιℓ")
+            if PyCall.pyversion.major == 2
+                path = joinpath(tmppath, "kind")
+            else
+                path = joinpath(tmppath, "ϵνιℓ")
+            end
             # Create a new virtual environment
             run(PyCall.python_cmd(`-m venv $path`, python=python))
             test_venv_has_python(path)

--- a/test/test_venv.jl
+++ b/test/test_venv.jl
@@ -27,6 +27,84 @@ using Compat: @info, @warn
 end
 
 
+function test_venv_has_python(path)
+    newpython = PyCall.python_cmd(venv=path).exec[1]
+    if !isfile(newpython)
+        @info """
+        Python executable $newpython does not exists.
+        This directory contains only the following files:
+        $(join(readdir(dirname(newpython)), '\n'))
+        """
+    end
+    @test isfile(newpython)
+end
+
+
+function test_venv_activation(path)
+    newpython = PyCall.python_cmd(venv=path).exec[1]
+
+    # Run a fresh Julia process with new Python environment
+    if VERSION < v"0.7.0-"
+        setup_code = ""
+    else
+        setup_code = Base.load_path_setup_code()
+    end
+    code = """
+    $setup_code
+    using PyCall
+    println(PyCall.pyimport("sys")[:executable])
+    println(PyCall.pyimport("sys")[:exec_prefix])
+    println(PyCall.pyimport("pip")[:__file__])
+    """
+    # Note that `pip` is just some arbitrary non-standard
+    # library.  Using standard library like `os` does not work
+    # because those files are not created.
+    env = copy(ENV)
+    env["PYCALL_JL_RUNTIME_PYTHON"] = newpython
+    jlcmd = setenv(`$(Base.julia_cmd()) --startup-file=no -e $code`, env)
+    if Compat.Sys.iswindows()
+        # Marking the test broken in Windows.  It seems that
+        # venv copies .dll on Windows and libpython check in
+        # PyCall.__init__ detects that.
+        @test_broken begin
+            output = read(jlcmd, String)
+            sys_executable, exec_prefix, mod_file = split(output, "\n")
+            newpython == sys_executable
+        end
+    else
+        output = read(jlcmd, String)
+        sys_executable, exec_prefix, mod_file = split(output, "\n")
+        @test newpython == sys_executable
+        @test startswith(exec_prefix, path)
+        @test startswith(mod_file, path)
+    end
+end
+
+
+@testset "virtualenv activation" begin
+    if Compat.Sys.which("virtualenv") === nothing
+        @info "No virtualenv command. Skipping the test..."
+    else
+        mktempdir() do path
+            run(`virtualenv $path`)
+            test_venv_has_python(path)
+
+            newpython = PyCall.python_cmd(venv=path).exec[1]
+            venv_libpython = PyCall.find_libpython(newpython)
+            if venv_libpython != PyCall.libpython
+                @info """
+                virtualenv created an environment with incompatible libpython:
+                    $venv_libpython
+                """
+                return
+            end
+
+            test_venv_activation(path)
+        end
+    end
+end
+
+
 @testset "venv activation" begin
     if Compat.Sys.isunix() && !startswith(PyCall.pyprogramname, "/usr/bin")
         @warn """
@@ -51,51 +129,8 @@ end
         mktempdir() do path
             # Create a new virtual environment
             run(PyCall.python_cmd(`-m venv $path`))
-            newpython = PyCall.python_cmd(venv=path).exec[1]
-            if !isfile(newpython)
-                @info """
-                Python executable $newpython does not exists.
-                This directory contains only the following files:
-                $(join(readdir(dirname(newpython)), '\n'))
-                """
-            end
-            @test isfile(newpython)
-
-            # Run a fresh Julia process with new Python environment
-            if VERSION < v"0.7.0-"
-                setup_code = ""
-            else
-                setup_code = Base.load_path_setup_code()
-            end
-            code = """
-            $setup_code
-            using PyCall
-            println(PyCall.pyimport("sys")[:executable])
-            println(PyCall.pyimport("sys")[:exec_prefix])
-            println(PyCall.pyimport("pip")[:__file__])
-            """
-            # Note that `pip` is just some arbitrary non-standard
-            # library.  Using standard library like `os` does not work
-            # because those files are not created.
-            env = copy(ENV)
-            env["PYCALL_JL_RUNTIME_PYTHON"] = newpython
-            jlcmd = setenv(`$(Base.julia_cmd()) --startup-file=no -e $code`, env)
-            if Compat.Sys.iswindows()
-                # Marking the test broken in Windows.  It seems that
-                # venv copies .dll on Windows and libpython check in
-                # PyCall.__init__ detects that.
-                @test_broken begin
-                    output = read(jlcmd, String)
-                    sys_executable, exec_prefix, mod_file = split(output, "\n")
-                    newpython == sys_executable
-                end
-            else
-                output = read(jlcmd, String)
-                sys_executable, exec_prefix, mod_file = split(output, "\n")
-                @test newpython == sys_executable
-                @test startswith(exec_prefix, path)
-                @test startswith(mod_file, path)
-            end
+            test_venv_has_python(path)
+            test_venv_activation(path)
         end
     end
 end

--- a/test/test_venv.jl
+++ b/test/test_venv.jl
@@ -26,9 +26,9 @@ function test_venv_activation(path)
     code = """
     $setup_code
     using PyCall
-    println(PyCall.pyimport("sys")[:executable])
-    println(PyCall.pyimport("sys")[:exec_prefix])
-    println(PyCall.pyimport("pip")[:__file__])
+    println(PyCall.pyimport("sys").executable)
+    println(PyCall.pyimport("sys").exec_prefix)
+    println(PyCall.pyimport("pip").__file__)
     """
     # Note that `pip` is just some arbitrary non-standard
     # library.  Using standard library like `os` does not work
@@ -93,14 +93,14 @@ end
     # Otherwise, `venv` does not work with this Python executable:
     # https://bugs.python.org/issue30811
     sys = PyCall.pyimport("sys")
-    if haskey(sys, :real_prefix)
+    if hasproperty(sys, :real_prefix)
         # sys.real_prefix is set by virtualenv and does not exist in
         # standard Python:
         # https://github.com/pypa/virtualenv/blob/16.0.0/virtualenv_embedded/site.py#L554
         candidates = [
-            PyCall.venv_python(sys[:real_prefix], "$(pyversion.major).$(pyversion.minor)"),
-            PyCall.venv_python(sys[:real_prefix], "$(pyversion.major)"),
-            PyCall.venv_python(sys[:real_prefix]),
+            PyCall.venv_python(sys.real_prefix, "$(pyversion.major).$(pyversion.minor)"),
+            PyCall.venv_python(sys.real_prefix, "$(pyversion.major)"),
+            PyCall.venv_python(sys.real_prefix),
             PyCall.pyprogramname,  # must exists
         ]
         python = candidates[findfirst(isfile, candidates)]

--- a/test/test_venv.jl
+++ b/test/test_venv.jl
@@ -1,5 +1,4 @@
-using PyCall, Compat, Compat.Test
-using Compat: @info, @warn
+using PyCall, Test
 
 
 function test_venv_has_python(path)
@@ -37,7 +36,7 @@ function test_venv_activation(path)
     env = copy(ENV)
     env["PYCALL_JL_RUNTIME_PYTHON"] = newpython
     jlcmd = setenv(`$(Base.julia_cmd()) --startup-file=no -e $code`, env)
-    if Compat.Sys.iswindows()
+    if Sys.iswindows()
         # Marking the test broken in Windows.  It seems that
         # venv copies .dll on Windows and libpython check in
         # PyCall.__init__ detects that.
@@ -58,9 +57,9 @@ end
 
 @testset "virtualenv activation" begin
     pyname = "python$(pyversion.major).$(pyversion.minor)"
-    if Compat.Sys.which("virtualenv") === nothing
+    if Sys.which("virtualenv") === nothing
         @info "No virtualenv command. Skipping the test..."
-    elseif Compat.Sys.which(pyname) === nothing
+    elseif Sys.which(pyname) === nothing
         @info "No $pyname command. Skipping the test..."
     else
         mktempdir() do tmppath

--- a/test/test_venv.jl
+++ b/test/test_venv.jl
@@ -82,11 +82,14 @@ end
 
 
 @testset "virtualenv activation" begin
+    pyname = "python$(pyversion.major).$(pyversion.minor)"
     if Compat.Sys.which("virtualenv") === nothing
         @info "No virtualenv command. Skipping the test..."
+    elseif Compat.Sys.which(pyname) === nothing
+        @info "No $pyname command. Skipping the test..."
     else
         mktempdir() do path
-            run(`virtualenv $path`)
+            run(`virtualenv --python=$pyname $path`)
             test_venv_has_python(path)
 
             newpython = PyCall.python_cmd(venv=path).exec[1]

--- a/test/test_venv.jl
+++ b/test/test_venv.jl
@@ -60,8 +60,18 @@ end
             env = copy(ENV)
             env["PYCALL_JL_RUNTIME_PYTHON"] = newpython
             jlcmd = setenv(`$(Base.julia_cmd()) -e $code`, env)
-            output = read(jlcmd, String)
-            @test newpython == output
+            if Compat.Sys.iswindows()
+                # Marking the test broken in Windows.  It seems that
+                # venv copies .dll on Windows and libpython check in
+                # PyCall.__init__ detects that.
+                @test_broken begin
+                    output = read(jlcmd, String)
+                    newpython == output
+                end
+            else
+                output = read(jlcmd, String)
+                @test newpython == output
+            end
         end
     end
 end


### PR DESCRIPTION
This PR grew out of a small feature addition to a patch that includes a few more. Here is a new summary:

* Main feature addition: Control Python environment at run-time by the environment variables `PYCALL_JL_RUNTIME_PYTHON` (and `PYCALL_JL_RUNTIME_PYTHONHOME`).
* fix #410: Support building Pycall against a Python executable generated by `python -m venv`.
* Refactoring: I merged how `Py_SetPythonHome` and `Py_SetProgramName` are `ccall`ed with and without `PYCALL_JL_RUNTIME_PYTHON`.  `wpyprogramname` and `wPYTHONHOME` are removed.

---

Original summary:

I suggest to let users control Python environment at runtime by (say) `ENV["PYCALL_JL_RUNTIME_PYTHON"]` (and `ENV["PYCALL_JL_RUNTIME_PYTHONHOME"]`).  This can be used to make sure that Julia and Python environments for a project are fully reproducible.  Combining `Pkg3.jl` and `pipenv`, a typical usage would be very simple:

```console
$ ls
activate.jl  Manifest.toml  Pipfile  Pipfile.lock  Project.toml
$ cat activate.jl
import Pkg
Pkg.activate(@__DIR__)
ENV["PYCALL_JL_RUNTIME_PYTHON"] = strip(read(setenv(`pipenv --py`, dir=@__DIR__), String))
$ julia -i activate.jl
julia> using PyCall
julia> pyimport("numpy")  # loads numpy specified by Pipfile
```
