### PR TITLE
Handle ModuleNotFoundError in pyimport

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -436,7 +436,7 @@ function pyimport(name::AbstractString)
     if ispynull(o)
         if pyerr_occurred()
             e = PyError("PyImport_ImportModule")
-            if e.T.o == @pyglobalobjptr(:PyExc_ImportError)
+            if pyisinstance(e.val, @pyglobalobjptr(:PyExc_ImportError))
                 # Expand message to help with common user confusions.
                 msg = """
 The Python package $name could not be found by pyimport. Usually this means

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -321,6 +321,18 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
     @test !ispynull(PyObject(3))
     @test ispynull(pydecref(PyObject(3)))
 
+    ex = try
+        pyimport("s p a m")
+    catch ex
+        ex
+    end
+    @test ex isa PyCall.PyError
+    @test occursin("could not be found by pyimport", ex.msg)
+    # Make sure we are testing ModuleNotFoundError here:
+    if PyCall.pyversion >= v"3.6"
+        @test pyisinstance(ex.val, pybuiltin("ModuleNotFoundError"))
+    end
+
     @test !ispynull(pyimport_conda("inspect", "not a conda package"))
     import Conda
     if PyCall.conda


### PR DESCRIPTION
Python 3.6 adds `ModuleNotFoundError` which is a subclass of
`ImportError`.  We need to handle all instances of `ImportError`
subclasses as `ImportError` to show instructions about Python
packaging.

https://docs.python.org/3/library/exceptions.html#ModuleNotFoundError