### PR TITLE
Safer pyjlwrap

### DIFF
--- a/src/pytype.jl
+++ b/src/pytype.jl
@@ -337,9 +337,15 @@ end
 unsafe_pyjlwrap_to_objref(o::PyPtr) =
   unsafe_pointer_to_objref(unsafe_load(convert(Ptr{Ptr{Cvoid}}, o), 3))
 
-pyjlwrap_repr(o::PyPtr) =
-    pystealref!(PyObject(o != C_NULL ? string("<PyCall.jlwrap ",unsafe_pyjlwrap_to_objref(o),">")
-                                     : "<PyCall.jlwrap NULL>"))
+function pyjlwrap_repr(o::PyPtr)
+    try
+        return pyreturn(o != C_NULL ? string("<PyCall.jlwrap ",unsafe_pyjlwrap_to_objref(o),">")
+                        : "<PyCall.jlwrap NULL>")
+    catch e
+        pyraise(e)
+        return PyPtr_NULL
+    end
+end
 
 function pyjlwrap_hash(o::PyPtr)
     h = hash(unsafe_pyjlwrap_to_objref(o))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -639,6 +639,7 @@ end
 
 struct Unprintable end
 Base.show(::IO, ::Unprintable) = error("show(::IO, ::Unprintable) called")
+Base.show(::IO, ::Type{Unprintable}) = error("show(::IO, ::Type{Unprintable}) called")
 
 py"""
 def try_repr(x):
@@ -648,11 +649,21 @@ def try_repr(x):
         return err
 """
 
+py"""
+def try_call(f):
+    try:
+        return f()
+    except Exception as err:
+        return err
+"""
+
 @testset "throwing show" begin
     unp = Unprintable()
     @test_throws Exception show(unp)
     @test py"try_repr"("printable") isa String
     @test pyisinstance(py"try_repr"(unp), pybuiltin("Exception"))
+    @test pyisinstance(py"try_call"(() -> throw(Unprintable())),
+                       pybuiltin("Exception"))
 end
 
 include("test_pyfncall.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -637,4 +637,22 @@ end
     @test anonymous.sys != PyNULL()
 end
 
+struct Unprintable end
+Base.show(::IO, ::Unprintable) = error("show(::IO, ::Unprintable) called")
+
+py"""
+def try_repr(x):
+    try:
+        return repr(x)
+    except Exception as err:
+        return err
+"""
+
+@testset "throwing show" begin
+    unp = Unprintable()
+    @test_throws Exception show(unp)
+    @test py"try_repr"("printable") isa String
+    @test pyisinstance(py"try_repr"(unp), pybuiltin("Exception"))
+end
+
 include("test_pyfncall.jl")


### PR DESCRIPTION
Without the first change, following script using PyJulia kills the whole process with "fatal: error thrown and no exception handler available." printed from libjulia runtime:

```python
from julia import Main
Spam = Main.eval("""
struct Spam end
function Base.show(io::IO, ::Spam)
    error("show(::IO, ::Spam) called")
end
Spam
""")
print(Spam())
```

There was a related problem when `pyraise` tries to render a unprintable object.  I fixed it too.  Note that `pyraise` invokes `showerror` first now.  This shows more informative error message in Python side.
