### PR TITLE
Allow @pydef to define classes with class variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,16 @@ Here's another example using [Tkinter](https://wiki.python.org/moin/TkInter):
     app = SampleApp()
     app[:mainloop]()
 
+Class variables are also supported:
+
+    using PyCall
+    @pydef mutable struct ObjectCounter
+        obj_count = 0 # Class variable
+        function __init__(::PyObject)
+            ObjectCounter[:obj_count] += 1
+        end
+    end
+
 ### GUI Event Loops
 
 For Python packages that have a graphical user interface (GUI),

--- a/src/pyclass.jl
+++ b/src/pyclass.jl
@@ -73,9 +73,9 @@ function parse_pydef(expr)
     method_syms = Dict{Any, Symbol}() # see below
     class_vars = Dict{Symbol, Any}()
     for line in lines
-        if line isa LineNumberNode || line isa Symbol || line.head == :line
-            continue
-        end
+        line isa LineNumberNode && continue
+        line isa Expr || error("Malformed line: $line")
+        line.head == :line && continue
         if isfunction(line)
             def_dict = splitdef(line)
             py_f = def_dict[:name]
@@ -112,6 +112,8 @@ function parse_pydef(expr)
             push!(function_defs, combinedef(jl_def_dict))
         elseif line.head == :(=) # Non function assignment
             class_vars[line.args[1]] = line.args[2]
+        else
+            error("Malformed line: $line")
         end
     end
     @assert(isempty(setdiff(keys(setter_dict), keys(getter_dict))),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -573,6 +573,14 @@ end
     end
 end
 
+# @pydef with class variable
+@pydef mutable struct ObjectCounter
+    obj_count = 1 - 1
+    function __init__(::PyObject)
+        ObjectCounter[:obj_count] += 1
+    end
+end
+
 @testset "pydef" begin
     d = Doubler(5)
     @test d[:x] == 5
@@ -583,6 +591,10 @@ end
 
     @test_throws ErrorException @pywith IgnoreError(false) error()
     @test (@pywith IgnoreError(true) error(); true)
+
+    @test ObjectCounter[:obj_count] == 0
+    a = ObjectCounter()
+    @test ObjectCounter[:obj_count] == 1
 end
 
 @testset "callback" begin


### PR DESCRIPTION
Before this commit, `@pydef` and `@pydef_object` did not support the creation of
python classes with [class variables][1]. I have expanded `@pydef` to support
class variables with the following syntax:

```julia
@pydef mutable struct ObjectCounter
    obj_count = 0 # Class variable
    function __init__(::PyObject)
        ObjectCounter[:obj_count] += 1
    end
end
```

closes #513

[1]: https://docs.python.org/3/tutorial/classes.html#class-and-instance-variables