### PR TITLE
Julia 0.6+ is supported and 0.7/1.0 really works

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 [![PyCall](http://pkg.julialang.org/badges/PyCall_0.5.svg)](http://pkg.julialang.org/?pkg=PyCall&ver=0.5)
 [![PyCall](http://pkg.julialang.org/badges/PyCall_0.6.svg)](http://pkg.julialang.org/?pkg=PyCall&ver=0.6)
-[![PyCall](http://pkg.julialang.org/badges/PyCall_0.7.svg)](http://pkg.julialang.org/?pkg=PyCall&ver=0.7)
 
 
 This package provides the ability to directly call and **fully
@@ -20,7 +19,7 @@ without copying them.
 ## Installation
 
 Within Julia, just use the package manager to run `Pkg.add("PyCall")` to
-install the files.  Julia 0.5 or later is required.
+install the files.  Julia 0.6 or later is required.
 
 The latest development version of PyCall is available from
 <https://github.com/stevengj/PyCall.jl>.  If you want to switch to


### PR DESCRIPTION
It seems to me 0.7 works according to: https://travis-ci.org/JuliaPy/PyCall.jl/jobs/456635014

The badge for 0.7, showing 1.16.1 failing isn't really helpful? Nor really the other for newer 1.17.1, but still old version, rather than showing for newest?

I'm not sure how to fix the badges. Is it better to say 0.5 is supported? Including the README on purpose in case you use an older PyCall.jl?