### PR TITLE
Use native sizes by default when parsing buffer format string

### DIFF
--- a/src/pybuffer.jl
+++ b/src/pybuffer.jl
@@ -239,7 +239,7 @@ function array_format(pybuf::PyBuffer)
     if length(fmt_str) > 1
         type_start_idx = 2
         if fmt_str[1] == '@' || fmt_str[1] == '^'
-            # defaults to native_byteorder: true, is_standard_size: false
+            # defaults to native_byteorder: true, use_native_sizes: true
         elseif fmt_str[1] == '<'
             native_byteorder = ENDIAN_BOM == 0x04030201
             use_native_sizes = false

--- a/src/pybuffer.jl
+++ b/src/pybuffer.jl
@@ -227,31 +227,35 @@ function array_format(pybuf::PyBuffer)
     # TODO: handle more cases: https://www.python.org/dev/peps/pep-3118/#additions-to-the-struct-string-syntax
     # refs: https://github.com/numpy/numpy/blob/v1.14.2/numpy/core/src/multiarray/buffer.c#L966
     #       https://github.com/numpy/numpy/blob/v1.14.2/numpy/core/_internal.py#L490
-    #       https://docs.python.org/2/library/struct.html#byte-order-size-and-alignment
+    #       https://docs.python.org/3/library/struct.html#byte-order-size-and-alignment
 
     # "NULL implies standard unsigned bytes ("B")" --pep 3118
     pybuf.buf.format == C_NULL && return UInt8, true
 
     fmt_str = get_format_str(pybuf)
     native_byteorder = true
+    use_native_sizes = true
     type_start_idx = 1
-    typestrs = standard_typestrs
     if length(fmt_str) > 1
         type_start_idx = 2
-        if fmt_str[1] == '='
+        if fmt_str[1] == '@' || fmt_str[1] == '^'
+            # defaults to native_byteorder: true, is_standard_size: false
         elseif fmt_str[1] == '<'
             native_byteorder = ENDIAN_BOM == 0x04030201
+            use_native_sizes = false
         elseif fmt_str[1] == '>' || fmt_str =='!'
             native_byteorder = ENDIAN_BOM == 0x01020304
-        elseif fmt_str[1] == '@' || fmt_str[1] == '^'
-            typestrs = native_typestrs
+            use_native_sizes = false
+        elseif fmt_str[1] == '='
+            use_native_sizes = false
         elseif fmt_str[1] == "Z"
             type_start_idx = 1
         else
             error("Unsupported format string: \"$fmt_str\"")
         end
     end
-    typestrs[fmt_str[type_start_idx:end]], native_byteorder
+    strs2types = use_native_sizes ? native_typestrs : standard_typestrs
+    strs2types[fmt_str[type_start_idx:end]], native_byteorder
 end
 
 #############################################################################

--- a/test/testpybuffer.jl
+++ b/test/testpybuffer.jl
@@ -36,11 +36,18 @@ pyutf8(s::String) = pyutf8(PyObject(s))
         end
 
         @testset "dtype should match eltype" begin
-            npy2jl = Dict(np["int64"][:__name__]=>Int64,
-                          np["int32"][:__name__]=>Int32)
-            nparr = arrpyo(1:10)
-            jltype = npy2jl[pystr(nparr["dtype"])]
-            @test eltype(convert(PyAny, nparr)) == jltype
+            npy2jl = Dict("int32"=>Int32, "float32"=>Float32,
+                          "int64"=>Int64, "float64"=>Float64)
+            for (pytype, jltype) in npy2jl
+                @testset "dtype $pytype should match eltype $jltype" begin
+                    jlarr = jltype[1:10;]
+                    nparr = arrpyo(jlarr, dtype=pytype)
+                    @test pystr(nparr["dtype"]) == pytype
+                    jlarr2 = convert(PyAny, nparr)
+                    @test eltype(jlarr2) == jltype
+                    @test jlarr2 == jlarr
+                end
+            end
         end
 
         @testset "NoCopyArray 1d" begin

--- a/test/testpybuffer.jl
+++ b/test/testpybuffer.jl
@@ -35,6 +35,14 @@ pyutf8(s::String) = pyutf8(PyObject(s))
             @test_throws ArgumentError PyArray(wrong_endian_arr)
         end
 
+        @testset "Get the right (native) dtype" begin
+            nparr = arrpyo(1:10)
+            npintstr = Int == Int64 ? "int64" : "int32"
+
+            # make sure we're dealing with an Int array
+            @test pystr(nparr["dtype"]) == npintstr
+        end
+
         @testset "NoCopyArray 1d" begin
             ao = arrpyo(1.0:10.0, "d")
             pybuf = PyBuffer(ao, PyBUF_ND_CONTIGUOUS)

--- a/test/testpybuffer.jl
+++ b/test/testpybuffer.jl
@@ -35,12 +35,12 @@ pyutf8(s::String) = pyutf8(PyObject(s))
             @test_throws ArgumentError PyArray(wrong_endian_arr)
         end
 
-        @testset "Get the right (native) dtype" begin
+        @testset "dtype should match eltype" begin
+            npy2jl = Dict(np["int64"][:__name__]=>Int64,
+                          np["int32"][:__name__]=>Int32)
             nparr = arrpyo(1:10)
-            npintstr = Int == Int64 ? "int64" : "int32"
-
-            # make sure we're dealing with an Int array
-            @test pystr(nparr["dtype"]) == npintstr
+            jltype = npy2jl[pystr(nparr["dtype"])]
+            @test eltype(convert(PyAny, nparr)) == jltype
         end
 
         @testset "NoCopyArray 1d" begin


### PR DESCRIPTION
Ahh oops. So, apparently you're supposed to use native sizes by default when parsing the buffer protocol format strings. I did the opposite in #487.

Current master
```
using PyCall
py"""
import numpy as np
"""
nparr = py"np.array([1,1,1,1])"o
nparr["dtype"]  # PyObject dtype('int64')
convert(PyAny, nparr)
```
returns `Int32[1,0,1,0]` \*
It should just be `Int[1,1,1,1]`

This actually caused me a bug in some relatively large distributed code, that I found very hard to track down. So karmically, pretty interesting.

At least it didn't make it to a release.

\* The [1, 0, 1, 0] is also in part due to a bug in f_contiguous for 1d arrays when `stride != sizeof(T)` - I will post a PR with a fix for that next week, I need to make some other changes to get the tests right for that. This is the minor positive to come out of this.