### PR TITLE
Restore support for non-contiguous PyArrays, fix f_contiguous, simplify copy(::PyArray)

### DIFF
--- a/src/pyarray.jl
+++ b/src/pyarray.jl
@@ -13,7 +13,7 @@ end
 
 function PyArray_Info(o::PyObject)
     # n.b. the pydecref(::PyBuffer) finalizer handles releasing the PyBuffer
-    pybuf = PyBuffer(o, PyBUF_ND_CONTIGUOUS)
+    pybuf = PyBuffer(o, PyBUF_ND_STRIDED)
     T, native_byteorder = array_format(pybuf)
     sz = size(pybuf)
     strd = strides(pybuf)
@@ -121,7 +121,7 @@ the Python buffer interface
 """
 function setdata!(a::PyArray{T,N}, o::PyObject) where {T,N}
     pybufinfo = a.info.pybuf
-    PyBuffer!(pybufinfo, o, PyBUF_ND_CONTIGUOUS)
+    PyBuffer!(pybufinfo, o, PyBUF_ND_STRIDED)
     dataptr = pybufinfo.buf.buf
     a.data = reinterpret(Ptr{T}, dataptr)
     a
@@ -294,7 +294,7 @@ function convert(::Type{Array{PyObject,N}}, o::PyObject) where N
     map(pyincref, convert(Array{PyPtr, N}, o))
 end
 
-array_format(o::PyObject) = array_format(PyBuffer(o, PyBUF_ND_CONTIGUOUS))
+array_format(o::PyObject) = array_format(PyBuffer(o, PyBUF_ND_STRIDED))
 
 """
 ```
@@ -319,7 +319,7 @@ correctly.
 """
 function NoCopyArray(o::PyObject)
     # n.b. the pydecref(::PyBuffer) finalizer handles releasing the PyBuffer
-    pybuf = PyBuffer(o, PyBUF_ND_CONTIGUOUS)
+    pybuf = PyBuffer(o, PyBUF_ND_STRIDED)
     T, native_byteorder = array_format(pybuf)
     !native_byteorder && throw(ArgumentError(
       "Only native endian format supported, format string: '$(get_format_str(pybuf))'"))


### PR DESCRIPTION
Changes by commit

1. [Add support for non-contiguous PyArrays](https://github.com/JuliaPy/PyCall.jl/commit/cccd18874984642d5bcbddaf4c625a71b420b4d7): Restore support for non-contiguous PyArrays (I think they used to work before #487?)
2. [Fix f_contiguous for 1d arrays](https://github.com/JuliaPy/PyCall.jl/pull/623/commits/ac2ea1e22adc5c4b94dfefb3839512ecdf8e91b2): without this non-contiguous 1d PyArrays could have the f_contig flag set incorrectly to true. This would cause an incorrect conversion to julia for such arrays with a `convert(PyAny, non_contig_1d_array)` (see the [1,0,1,0] example in #621/the "1d non-contiguous" testset in this PR)
3. [Simplify Copy(::PyArray)](https://github.com/JuliaPy/PyCall.jl/pull/623/commits/8e5be56b6cd15cc4308176da44e33de3107ba403): With f_contiguous correct for 1d, copy(::PyArray) could be simplified