### PR TITLE
deprecate o[integer] so that we can transition to 0-based access

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -287,25 +287,25 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
         @test o.real == 1
     end
 
-    @testset "[]-based sequence access" begin
+    @testset "get-based sequence access" begin
         a1=[5,8,6]; a2=rand(3,4); a3=rand(3,4,5); o1=PyObject(a1); o2=PyObject(a2); o3=PyObject(a3)
-        @test [o1[i] for i in eachindex(a1)] == a1
-        @test [o1[end-(i-1)] for i in eachindex(a1)] == reverse(a1)
-        @test all(o2[1] == collect(a2[1,:]))
+        @test [get(o1,i-1) for i in eachindex(a1)] == a1
+        @test [get(o1,-i) for i in eachindex(a1)] == reverse(a1)
+        @test all(get(o2,0) == collect(a2[1,:]))
         @test length(o1) == length(o2) == length(o3) == 3
-        o1[end-1] = 7
-        @test o1[2] == 7
+        set!(o1,-1,7)
+        @test get(o1,-1) == 7
 
         # multiple indices are passed as tuples, but this is apparently
         # only supported by numpy arrays.
         if PyCall.npy_initialized
-            @test [o2[i,j] for i=1:3, j=1:4] == a2
-            @test [o3[i,j,k] for i=1:3, j=1:4, k=1:5] == a3
-            @test all(o3[2,3] == collect(a3[2,3,:]))
-            o2[2,3] = 8
-            @test o2[2,3] == 8
-            o3[2,3,4] = 9
-            @test o3[2,3,4] == 9
+            @test [get(o2,(i-1,j-1)) for i=1:3, j=1:4] == a2
+            @test [get(o3,(i-1,j-1,k-1)) for i=1:3, j=1:4, k=1:5] == a3
+            @test all(get(o3, (1,2)) == collect(a3[2,3,:]))
+            set!(o2, (1,2), 8)
+            @test get(o2, (1,2)) == 8
+            set!(o3, (1,2,3), 9)
+            @test get(o3, (1,2,3)) == 9
         end
     end
 

--- a/test/testpybuffer.jl
+++ b/test/testpybuffer.jl
@@ -144,8 +144,8 @@ pyutf8(s::String) = pyutf8(PyObject(s))
             nca = NoCopyArray(ao)
             @test !(nca isa PermutedDimsArray)
             @test nca isa Array
-            @test nca[3] == ao[3]
-            @test nca[4] == ao[4]
+            @test nca[3] == get(ao,2)
+            @test nca[4] == get(ao,3)
         end
 
         @testset "NoCopyArray 2d f-contig" begin
@@ -162,8 +162,8 @@ pyutf8(s::String) = pyutf8(PyObject(s))
             @test nca isa Array
             @test size(nca) == (3,4)
             @test strides(nca) == (1,3)
-            @test nca[3,2] == ao[3,2]
-            @test nca[2,3] == ao[2,3]
+            @test nca[3,2] == get(ao, (2,1))
+            @test nca[2,3] == get(ao, (1,2))
         end
 
         @testset "NoCopyArray 3d c-contig" begin
@@ -179,8 +179,8 @@ pyutf8(s::String) = pyutf8(PyObject(s))
             @test !(nca isa Array)
             @test size(nca) == (3,4,5)
             @test strides(nca) == (20,5,1)
-            @test nca[2,3,4] == ao[2,3,4]
-            @test nca[3,2,4] == ao[3,2,4]
+            @test nca[2,3,4] == get(ao, (1,2,3))
+            @test nca[3,2,4] == get(ao, (2,1,3))
         end
 
         @testset "isbuftype" begin


### PR DESCRIPTION
Now that `o.foo` mirrors Python, we also want `o[foo]` to mirror Python.  Unfortunately, PyCall currently makes `o[integer]` in Julia act like `o[integer-1]` in Python, to emulate 1-based access.   This PR deprecates 1-based indexing of `PyObject` so that in PyCall 2.0 we can switch to 0-based indexing.