### PR TITLE
deprecate pywrap

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ roundtrip(x) = roundtrip(PyAny, x)
 roundtripeq(T, x) = roundtrip(T, x) == x
 roundtripeq(x) = roundtrip(x) == x
 
-@pyimport math
+const math = pyimport("math")
 
 struct TestConstruct
     x


### PR DESCRIPTION
`@pyimport` and `pywrap` are no longer needed thanks to #517.  (They were a crude hack to emulate dot overloading.)

Closes #329.  Closes #66.