### PR TITLE
Make ?obj.property work for obj::PyObject

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -896,6 +896,7 @@ end
 # Expose Python docstrings to the Julia doc system
 
 Docs.getdoc(o::PyObject) = Text(convert(String, o."__doc__"))
+Docs.Binding(o::PyObject, s::Symbol) = getproperty(o, s)
 
 #########################################################################
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -418,10 +418,14 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
     def foo():
         "foo docstring"
         return 0
+    class bar:
+        foo = foo
     """
     global foo354 = py"foo"
+    global barclass = py"bar"
     # use 'content' since `Text` objects test equality by object identity
     @test @doc(foo354).content == "foo docstring"
+    @test @doc(barclass.foo).content == "foo docstring"
 
     # binary operators
     for b in (4, PyObject(4))


### PR DESCRIPTION
Before:

```julia
julia> os = pyimport("os")
PyObject <module 'os' from '/home/takafumi/.virtualenvs/julia/lib/python3.7/os.py'>

help?> os.path.join
ERROR: MethodError: no method matching Base.Docs.Binding(::PyObject, ::Symbol)
...
```

After:

```julia
help?> os.path.join
Join two or more pathname components, inserting '/' as needed.
    If any component is an absolute path, all previous path components
    will be discarded.  An empty last part will result in a path that
    ends with a separator.
```
