### PR TITLE
Stop all GUI event loops before Py_Finalize

### DIFF
--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -75,6 +75,7 @@ function _set_finalized()
 end
 
 function Py_Finalize()
+    pygui_stop_all()
     ccall(@pysym(:Py_Finalize), Cvoid, ())
 end
 


### PR DESCRIPTION
Before this PR, using Python GUI and invoking some I/O in `atexit` resulted in a segfault:

```julia
$ julia --startup-file=no --banner=no
julia> atexit() do
           run(`echo hello`)
       end

julia> import PyPlot
       PyPlot.plot([1], [2], "o")
1-element Array{PyCall.PyObject,1}:
 PyObject <matplotlib.lines.Line2D object at 0x7fbd5b93bda0>

julia>

signal (11): Segmentation fault
in expression starting at REPL[2]:0
hello
PyUnicode_InternInPlace at /usr/lib/libpython3.7m.so.1.0 (unknown line)
_PyUnicode_FromId at /usr/lib/libpython3.7m.so.1.0 (unknown line)
_PyType_LookupId at /usr/lib/libpython3.7m.so.1.0 (unknown line)
unknown function (ip: 0x7fbd7df7e773)
PyObject_GetAttrString at /usr/lib/libpython3.7m.so.1.0 (unknown line)
getproperty at /home/takafumi/.julia/dev/PyCall/src/PyCall.jl:295
#7 at /home/takafumi/.julia/dev/PyCall/src/gui.jl:203
#448 at ./event.jl:556
jl_fptr_trampoline at /home/takafumi/repos/watch/julia/src/gf.c:1914
jl_apply_generic at /home/takafumi/repos/watch/julia/src/gf.c:2269
jl_apply at /home/takafumi/repos/watch/julia/src/julia.h:1577 [inlined]
start_task at /home/takafumi/repos/watch/julia/src/task.c:572
unknown function (ip: 0xffffffffffffffff)
Allocations: 12980316 (Pool: 12978709; Big: 1607); GC: 28
zsh: segmentation fault (core dumped)
```

Note the line `PyCall/src/gui.jl:203` in above stacktrace.  That's inside `Tk_eventloop`.

To avoid the segfault, we need to stop all GUI eventloops before calling `Py_Finalize` C API.
