### PR TITLE
Do not throw KeyError from property access

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -292,11 +292,7 @@ function getproperty(o::PyObject, s::AbstractString)
     if ispynull(o)
         throw(ArgumentError("ref of NULL PyObject"))
     end
-    p = ccall((@pysym :PyObject_GetAttrString), PyPtr, (PyPtr, Cstring), o, s)
-    if p == C_NULL
-        pyerr_clear()
-        throw(KeyError(s))
-    end
+    p = @pycheckn ccall((@pysym :PyObject_GetAttrString), PyPtr, (PyPtr, Cstring), o, s)
     return PyObject(p)
 end
 
@@ -313,11 +309,8 @@ function _setproperty!(o::PyObject, s::Union{Symbol,AbstractString}, v)
     if ispynull(o)
         throw(ArgumentError("assign of NULL PyObject"))
     end
-    if -1 == ccall((@pysym :PyObject_SetAttrString), Cint,
-                   (PyPtr, Cstring, PyPtr), o, s, PyObject(v))
-        pyerr_clear()
-        throw(KeyError(s))
-    end
+    @pycheckz ccall((@pysym :PyObject_SetAttrString), Cint,
+                    (PyPtr, Cstring, PyPtr), o, s, PyObject(v))
     o
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -263,7 +263,7 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
     @test getproperty(A, "B") == py"A.B"
     @test :B in propertynames(A)
     @test A.B.C == 1
-    @test_throws KeyError A.X
+    @test_throws PyCall.PyError A.X
     setproperty!(py"A.B", "C", 2)
     @test py"A.B.C" == 2
 
@@ -535,7 +535,7 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
 
     # Test getattr fallback
     @test PyObject(TestConstruct(1)).x == 1
-    @test_throws KeyError PyObject(TestConstruct(1)).y
+    @test_throws PyCall.PyError PyObject(TestConstruct(1)).y
 
     # iterating over Julia objects in Python:
     @test py"[x**2 for x in $(PyCall.pyjlwrap_new(1:4))]" ==

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -262,10 +262,8 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
     @test hasproperty(A, "B")
     @test getproperty(A, "B") == py"A.B"
     @test :B in propertynames(A)
-    @static if VERSION >= v"0.7-"
-        @test A.B.C == 1
-        @test_throws KeyError A.X
-    end
+    @test A.B.C == 1
+    @test_throws KeyError A.X
     setproperty!(py"A.B", "C", 2)
     @test py"A.B.C" == 2
 


### PR DESCRIPTION
We don't use `setindex!` etc. anymore so it's a bit strange to throw `KeyError`.  Julia has no AttributeError equivalent so throwing PyError seems to be an obvious straightforward solution.

However, maybe we should wait until PyCall 2.0 as we still only deprecated indexing API and haven't completely removed it.
