### PR TITLE
Make PyJulia work with --compiled-modules=no

### DIFF
--- a/src/startup.jl
+++ b/src/startup.jl
@@ -80,6 +80,9 @@ else
     # If we're not in charge, assume the user is installing necessary python
     # libraries rather than messing with their configuration
     const conda = false
+    # Top-level code (`_current_python`) needs `pyprogramname`.  We
+    # don't need its value but we need to assign something to it:
+    const pyprogramname = ""
 end
 
 const pyversion = vparse(split(Py_GetVersion(libpy_handle))[1])


### PR DESCRIPTION
I added support for `--compiled_modules=no` in PyJulia https://github.com/JuliaPy/pyjulia/pull/236 (which can be used for yet another workaround for the precompilation issue).  But, it requires a small fix in PyCall.jl.
