### PR TITLE
fix array2py and friends for adjoints etc.

### DIFF
--- a/src/numpy.jl
+++ b/src/numpy.jl
@@ -190,11 +190,17 @@ function PyObject(a::StridedArray{T}) where T<:PYARR_TYPES
     try
         return NpyArray(a, false)
     catch
-        array2py(a) # fallback to non-NumPy version
+        return array2py(a) # fallback to non-NumPy version
     end
 end
 
-PyReverseDims(a::StridedArray{T}) where {T<:PYARR_TYPES} = NpyArray(a, true)
+function PyReverseDims(a::StridedArray{T,N}) where {T<:PYARR_TYPES,N}
+    try
+        return NpyArray(a, true)
+    catch
+        return array2py(a, permutedims(a, N:-1:1)) # fallback to non-NumPy version
+    end
+end
 PyReverseDims(a::BitArray) = PyReverseDims(Array(a))
 
 # fallback to physically transposing the array

--- a/src/numpy.jl
+++ b/src/numpy.jl
@@ -198,7 +198,7 @@ function PyReverseDims(a::StridedArray{T,N}) where {T<:PYARR_TYPES,N}
     try
         return NpyArray(a, true)
     catch
-        return array2py(a, permutedims(a, N:-1:1)) # fallback to non-NumPy version
+        return array2py(permutedims(a, N:-1:1)) # fallback to non-NumPy version
     end
 end
 PyReverseDims(a::BitArray) = PyReverseDims(Array(a))

--- a/src/numpy.jl
+++ b/src/numpy.jl
@@ -197,6 +197,10 @@ end
 PyReverseDims(a::StridedArray{T}) where {T<:PYARR_TYPES} = NpyArray(a, true)
 PyReverseDims(a::BitArray) = PyReverseDims(Array(a))
 
+# fallback to physically transposing the array
+PyReverseDims(a::AbstractArray{<:Any,N}) where {N} = PyObject(permutedims(a, N:-1:1))
+PyReverseDims(a::AbstractMatrix) = PyObject(permutedims(a))
+
 """
     PyReverseDims(array)
 
@@ -209,3 +213,9 @@ libraries that expect row-major data.
 PyReverseDims(a::AbstractArray)
 
 #########################################################################
+
+# transposed arrays can be passed to NumPy without copying
+PyObject(a::Union{LinearAlgebra.Adjoint{<:Real},LinearAlgebra.Transpose}) =
+    PyReverseDims(a.parent)
+
+PyObject(a::LinearAlgebra.Adjoint) = PyObject(Matrix(a)) # non-real arrays require a copy

--- a/src/pybuffer.jl
+++ b/src/pybuffer.jl
@@ -251,7 +251,7 @@ function array_format(pybuf::PyBuffer)
             use_native_sizes = false
         elseif fmt_str[1] == '='
             use_native_sizes = false
-        elseif fmt_str[1] == "Z"
+        elseif fmt_str[1] == 'Z'
             type_start_idx = 1
         else
             error("Unsupported format string: \"$fmt_str\"")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,8 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
     @test roundtripeq(C_NULL) && roundtripeq(convert(Ptr{Cvoid}, 12345))
     @test roundtripeq([1,3,4,5]) && roundtripeq([1,3.2,"hello",true])
     @test roundtripeq([1 2 3;4 5 6]) && roundtripeq([1. 2 3;4 5 6])
+    @test roundtripeq([1. 2 3;4 5 6]')
+    @test roundtripeq([1.0+2im 2+3im 3;4 5 6]')
     @test roundtripeq((1,(3.2,"hello"),true)) && roundtripeq(())
     @test roundtripeq(Int32)
     @test roundtripeq(Dict(1 => "hello", 2 => "goodbye")) && roundtripeq(Dict())
@@ -119,6 +121,7 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
     array2py2arrayeq(x) = PyCall.py2array(Float64,PyCall.array2py(x)) == x
     @test array2py2arrayeq(rand(3))
     @test array2py2arrayeq(rand(3,4))
+    @test array2py2arrayeq(rand(3,4)')
     @test array2py2arrayeq(rand(3,4,5))
 
     @test roundtripeq(2:10) && roundtripeq(10:-1:2)


### PR DESCRIPTION
Fixes `array2py` to use `CartesianIndex` rather than linear indexing.  Also adds special-case conversions for `Transpose` and `Adjoint` arrays.

Closes JuliaPy/PyPlot.jl#380, JuliaPy/PyPlot.jl#400, JuliaPy/PyPlot.jl#391, JuliaPy/PyPlot.jl#362.

Also has a bugfix for a typo in our `array_format(::PyBuffer)` function for complex arrays.