### PR TITLE
Fix findfirst usage for Julia 1.0

### DIFF
--- a/src/startup.jl
+++ b/src/startup.jl
@@ -54,7 +54,8 @@ else
             (Ptr{Cvoid}, Ptr{UInt16}, UInt32),
             libpy_handle, pathbuf, length(pathbuf))
         @assert ret != 0
-        libname = String(Base.transcode(UInt8, pathbuf[1:findfirst(pathbuf, 0)-1]))
+        pathlen = something(findfirst(iszero, pathbuf)) - 1
+        libname = String(Base.transcode(UInt8, pathbuf[1:pathlen]))
         if (Libdl.dlopen_e(libname) != C_NULL)
             const libpython = libname
         else


### PR DESCRIPTION
Without this change, PyJulia (`symbols_present == true`) path of startup.jl in Windows yields

```
LoadError: LoadError: MethodError: no method matching findfirst(::Array{UInt16,1}, ::Int64)
Closest candidates are:
  findfirst(::Union{AbstractString, AbstractArray}) at array.jl:1661
  findfirst(!Matched::Function, ::Any) at array.jl:1735
  findfirst(::Any) at array.jl:1652
in expression starting at C:\Users\appveyor\.julia\packages\PyCall\RQjD7\src\startup.jl:41
in expression starting at C:\Users\appveyor\.julia\packages\PyCall\RQjD7\src\PyCall.jl:37
```

(see https://ci.appveyor.com/project/Keno/pyjulia/builds/22976283/job/gqgiddula060yi1e#L417 which is the result of https://github.com/tkf/pyjulia/commit/7618f648d628403b98d606e9c2d1a00cae3159e3 in https://github.com/JuliaPy/pyjulia/pull/236)

After this change, PyJulia works: https://ci.appveyor.com/project/Keno/pyjulia/builds/22977464/job/3wko54kx8yyav91j#L395; https://github.com/tkf/pyjulia/pull/236/commits/1a2efe75f99b9f542e201fb6df49f205f1e0f99b
