### PR TITLE
various fixes to array conversions

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -404,7 +404,7 @@ function py2array(T, o::PyObject)
     py2array(T, A, o, 1, 1) # fixme: faster conversion for supported buffer types?
 end
 
-function convert(::Type{Vector{T}}, o::PyObject) where T
+function py2vector(T, o::PyObject)
     len = ccall((@pysym :PySequence_Size), Int, (PyPtr,), o)
     if len < 0 || # not a sequence
        len+1 < 0  # object pretending to be a sequence of infinite length
@@ -413,6 +413,7 @@ function convert(::Type{Vector{T}}, o::PyObject) where T
     end
     py2array(T, Array{pyany_toany(T)}(undef, len), o, 1, 1)
 end
+convert(::Type{Vector{T}}, o::PyObject) where T = py2vector(T, o)
 
 convert(::Type{Array}, o::PyObject) = map(identity, py2array(PyAny, o))
 convert(::Type{Array{T}}, o::PyObject) where {T} = py2array(T, o)

--- a/src/pyarray.jl
+++ b/src/pyarray.jl
@@ -158,6 +158,7 @@ unsafe_data_load(a::PyArray, i::Integer) = GC.@preserve a unsafe_load(a.data, i)
 
 @inline data_index(a::PyArray{<:Any,N}, i::CartesianIndex{N}) where {N} =
     1 + sum(ntuple(dim -> (i[dim]-1) * a.st[dim], Val{N}())) # Val lets julia unroll/inline
+data_index(a::PyArray{<:Any,0}, i::CartesianIndex{0}) = 1
 
 # handle passing fewer/more indices than dimensions by canonicalizing to M==N
 @inline function fixindex(a::PyArray{<:Any,N}, i::CartesianIndex{M}) where {M,N}

--- a/src/pyarray.jl
+++ b/src/pyarray.jl
@@ -50,6 +50,7 @@ identical memory layout to a Julia `Array` of the same size.
 `st` should be the stride(s) *in bytes* between elements in each dimension
 """
 function f_contiguous(::Type{T}, sz::NTuple{N,Int}, st::NTuple{N,Int}) where {T,N}
+    N == 0 && return true # 0-dimensional arrays have 1 element, always contiguous
     if st[1] != sizeof(T)
         # not contiguous
         return false

--- a/src/pyarray.jl
+++ b/src/pyarray.jl
@@ -156,7 +156,7 @@ end
 
 unsafe_data_load(a::PyArray, i::Integer) = GC.@preserve a unsafe_load(a.data, i)
 
-@inline data_index(a::PyArray{<:Any,N}, i::Union{NTuple{N,<:Integer},CartesianIndex{N}}) where {N} =
+@inline data_index(a::PyArray{<:Any,N}, i::CartesianIndex{N}) where {N} =
     1 + sum(ntuple(dim -> (i[dim]-1) * a.st[dim], Val{N}())) # Val lets julia unroll/inline
 
 # handle passing fewer/more indices than dimensions by canonicalizing to M==N

--- a/src/pyarray.jl
+++ b/src/pyarray.jl
@@ -154,10 +154,7 @@ function copy(a::PyArray{T,N}) where {T,N}
     return A
 end
 
-unsafe_data_load(a::PyArray) = GC.@preserve a unsafe_load(a.data)
 unsafe_data_load(a::PyArray, i::Integer) = GC.@preserve a unsafe_load(a.data, i)
-
-getindex(a::PyArray{T,0}) where {T} = unsafe_data_load(a)
 
 @inline data_index(a::PyArray{<:Any,N}, i::Union{NTuple{N,<:Integer},CartesianIndex{N}}) where {N} =
     1 + sum(ntuple(dim -> (i[dim]-1) * a.st[dim], Val{N}())) # Val lets julia unroll/inline

--- a/src/pybuffer.jl
+++ b/src/pybuffer.jl
@@ -47,8 +47,7 @@ the python c-api function `PyObject_GetBuffer()`, unless o.obj is a PyPtr(C_NULL
 function pydecref(o::PyBuffer)
     # note that PyBuffer_Release sets o.obj to NULL, and
     # is a no-op if o.obj is already NULL
-    # TODO change to `Ref{PyBuffer}` when 0.6 is dropped.
-    _finalized[] || ccall(@pysym(:PyBuffer_Release), Cvoid, (Any,), o)
+    _finalized[] || ccall(@pysym(:PyBuffer_Release), Cvoid, (Ref{PyBuffer},), o)
     o
 end
 
@@ -96,10 +95,9 @@ end
 # Strides in bytes
 Base.strides(b::PyBuffer) = ((stride(b,i) for i in 1:b.buf.ndim)...,)
 
-# TODO change to `Ref{PyBuffer}` when 0.6 is dropped.
 iscontiguous(b::PyBuffer) =
     1 == ccall((@pysym :PyBuffer_IsContiguous), Cint,
-               (Any, Cchar), b, 'A')
+               (Ref{PyBuffer}, Cchar), b, 'A')
 
 #############################################################################
 # pybuffer constant values from Include/object.h
@@ -122,34 +120,34 @@ function PyBuffer(o::Union{PyObject,PyPtr}, flags=PyBUF_SIMPLE)
 end
 
 function PyBuffer!(b::PyBuffer, o::Union{PyObject,PyPtr}, flags=PyBUF_SIMPLE)
-    # TODO change to `Ref{PyBuffer}` when 0.6 is dropped.
     pydecref(b) # ensure b is properly released
     @pycheckz ccall((@pysym :PyObject_GetBuffer), Cint,
-                     (PyPtr, Any, Cint), o, b, flags)
+                     (PyPtr, Ref{PyBuffer}, Cint), o, b, flags)
     return b
 end
 
-"""
-`isbuftype(o::Union{PyObject,PyPtr})`
-Returns true if the python object `o` supports the buffer protocol as a strided
-array. False if not.
-"""
-function isbuftype(o::Union{PyObject,PyPtr})
+# like isbuftype, but modifies caller's PyBuffer
+function isbuftype!(o::Union{PyObject,PyPtr}, b::PyBuffer)
     # PyObject_CheckBuffer is defined in a header file here: https://github.com/python/cpython/blob/ef5ce884a41c8553a7eff66ebace908c1dcc1f89/Include/abstract.h#L510
     # so we can't access it easily. It basically just checks if PyObject_GetBuffer exists
     # So we'll just try call PyObject_GetBuffer and check for success/failure
-    b = PyBuffer()
     ret = ccall((@pysym :PyObject_GetBuffer), Cint,
                      (PyPtr, Any, Cint), o, b, PyBUF_ND_STRIDED)
     if ret != 0
         pyerr_clear()
-    else
-        # handle pointer types
-        T, native_byteorder = array_format(b)
-        T <: Ptr && (ret = 1)
     end
     return ret == 0
 end
+
+"""
+    isbuftype(o::Union{PyObject,PyPtr})
+
+Returns `true` if the python object `o` supports the buffer protocol as a strided
+array. `false` if not.
+
+If a new `PyBuffer()` is passed for the optional `b` argument, it is initialized
+"""
+isbuftype(o::Union{PyObject,PyPtr}) = isbuftype!(o, PyBuffer())
 
 #############################################################################
 
@@ -195,7 +193,8 @@ end
 # ref: https://github.com/numpy/numpy/blob/v1.14.2/numpy/core/src/multiarray/buffer.c#L966
 
 const standard_typestrs = Dict{String,DataType}(
-                           "?"=>Bool,        "P"=>Ptr{Cvoid},
+                           "?"=>Bool,
+                           "P"=>Ptr{Cvoid},  "O"=>PyPtr,
                            "b"=>Int8,        "B"=>UInt8,
                            "h"=>Int16,       "H"=>UInt16,
                            "i"=>Int32,       "I"=>UInt32,
@@ -208,7 +207,8 @@ const standard_typestrs = Dict{String,DataType}(
                            "Zf"=>ComplexF32, "Zd"=>ComplexF64)
 
 const native_typestrs = Dict{String,DataType}(
-                           "?"=>Bool,        "P"=>Ptr{Cvoid},
+                           "?"=>Bool,
+                           "P"=>Ptr{Cvoid},  "O"=>PyPtr,
                            "b"=>Int8,        "B"=>UInt8,
                            "h"=>Cshort,      "H"=>Cushort,
                            "i"=>Cint,        "I"=>Cuint,

--- a/src/pybuffer.jl
+++ b/src/pybuffer.jl
@@ -144,8 +144,6 @@ end
 
 Returns `true` if the python object `o` supports the buffer protocol as a strided
 array. `false` if not.
-
-If a new `PyBuffer()` is passed for the optional `b` argument, it is initialized
 """
 isbuftype(o::Union{PyObject,PyPtr}) = isbuftype!(o, PyBuffer())
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,6 +90,13 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
             @test convert(PyAny, PyReverseDims(A)) == permutedims(A, [3,2,1])
             @test convert(PyAny, PyReverseDims(BitArray(B))) == permutedims(B, [3,2,1])
         end
+        # test dtype=object:
+        let o = pycall(pyimport("numpy").array, PyObject, [3,4,5], dtype=pybuiltin("object"))
+            @test pytype_query(o) == Array{PyObject}
+            @test PyAny(o) == [3,4,5]
+            @test eltype(PyArray(o)) == PyPtr
+            @test pyincref.(PyArray(o)) == [3,4,5]
+        end
     end
     @test PyVector(PyObject([1,3.2,"hello",true])) == [1,3.2,"hello",true]
     @test PyDict(PyObject(Dict(1 => "hello", 2 => "goodbye"))) == Dict(1 => "hello", 2 => "goodbye")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,11 +91,15 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
             @test convert(PyAny, PyReverseDims(BitArray(B))) == permutedims(B, [3,2,1])
         end
         # test dtype=object:
-        let o = pycall(pyimport("numpy").array, PyObject, [3,4,5], dtype=pybuiltin("object"))
-            @test pytype_query(o) == Array{PyObject}
-            @test PyAny(o) == [3,4,5]
-            @test eltype(PyArray(o)) == PyPtr
-            @test pyincref.(PyArray(o)) == [3,4,5]
+        for a in ([3,4,5], [3 4 5;6 7 8])
+            let o = pycall(pyimport("numpy").array, PyObject, a, dtype=pybuiltin("object"))
+                @test pytype_query(o) == Array{PyObject}
+                for T in (PyAny, Array{PyObject}, Array{PyObject,ndims(a)})
+                    @test convert(T, o) == a
+                end
+                @test eltype(PyArray(o)) == PyPtr
+                @test GC.@preserve(o, pyincref.(PyArray(o))) == a
+            end
         end
     end
     @test PyVector(PyObject([1,3.2,"hello",true])) == [1,3.2,"hello",true]

--- a/test/testpybuffer.jl
+++ b/test/testpybuffer.jl
@@ -199,6 +199,16 @@ pyutf8(s::String) = pyutf8(PyObject(s))
             @test all(pyarr[1:10] .== 11.0:20.0)
         end
 
+        @testset "bounds checks" begin
+            a = PyArray(pytestarray(3,4,1))
+            @test a[2,3,1] == a[2,3] == a[2,3,1,1,1] == a[8]
+            @test_throws BoundsError a[5,3,1]
+            @test_throws BoundsError a[2,6,1]
+            @test_throws BoundsError a[2,3,3]
+            @test_throws BoundsError a[2,3,1,2]
+            @test_throws BoundsError PyArray(pytestarray(3,4,2))[2,3]
+        end
+
         @testset "similar on PyArray PyVec getindex" begin
             jlarr1 = [1:10;]
             jlarr2 = hcat([1:10;], [1:10;])

--- a/test/testpybuffer.jl
+++ b/test/testpybuffer.jl
@@ -88,7 +88,7 @@ pyutf8(s::String) = pyutf8(PyObject(s))
             # check all is in order
             for i in 1:size(pyarr, 1)
                 for j in 1:size(pyarr, 1)
-                    @test jlcopy[i,j] == pyarr[i,j]
+                    @test jlcopy[i,j] == pyarr[i,j] == pyarr[i,j,1] == pyarr[CartesianIndex(i,j)]
                 end
             end
             # check it's not aliasing the same data

--- a/test/testpybuffer.jl
+++ b/test/testpybuffer.jl
@@ -209,4 +209,9 @@ pyutf8(s::String) = pyutf8(PyObject(s))
             @test all(pyarr2[1:10, 1:2] .== jlarr2)
         end
     end
+
+    # ctypes.c_void_p supports the buffer protocol as a 0-dimensional array
+    let p = convert(Ptr{Cvoid}, 12345)
+        @test PyArray(PyObject(p))[] == p
+    end
 end


### PR DESCRIPTION
Add bounds-checking, GC rooting, and `CartesianIndex` support in `PyArray`. Fixes conversion for arrays of pointers/pyptrs and 0-dimensional arrays.

Fixes JuliaPy/PyPlot.jl#431