### PR TITLE
fix aot script

### DIFF
--- a/aot/compile.jl
+++ b/aot/compile.jl
@@ -7,7 +7,7 @@ exec "${JULIA:-julia}" "$@" ${BASH_SOURCE[0]}
 using Pkg
 Pkg.activate(@__DIR__)
 Pkg.add("MacroTools")
-Pkg.develop(PackageSpec(path=dirname(@__DIR__)))
+Pkg.develop(PackageSpec(name="PyCall", path=dirname(@__DIR__)))
 Pkg.build("PyCall")
 Pkg.activate()
 


### PR DESCRIPTION
This PR fixes the following `LoadError`.

Running `compile.jl` we obtain the following error:

```bash
$ julia -e 'import Pkg; Pkg.pkg"add PyCall#master"'
$ cd ~/.julia/packages/PyCall/guUh9/
$ aot/compile.jl
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
 Resolving package versions...
  Updating `~/.julia/packages/PyCall/guUh9/aot/Project.toml`
  [1914dd2f] + MacroTools v0.4.5
  Updating `~/.julia/packages/PyCall/guUh9/aot/Manifest.toml`
  [34da2185] + Compat v2.1.0
  [1914dd2f] + MacroTools v0.4.5
  [2a0f44e3] + Base64
  [ade2ca70] + Dates
  [8bb1440f] + DelimitedFiles
  [8ba89e20] + Distributed
  [b77e0a4c] + InteractiveUtils
  [76f85450] + LibGit2
  [8f399da3] + Libdl
  [37e2e46d] + LinearAlgebra
  [56ddb016] + Logging
  [d6f4376e] + Markdown
  [a63ad114] + Mmap
  [44cfe95a] + Pkg
  [de0858da] + Printf
  [3fa0cd96] + REPL
  [9a3f8284] + Random
  [ea8e919c] + SHA
  [9e88b42a] + Serialization
  [1a1011a3] + SharedArrays
  [6462fe0b] + Sockets
  [2f01184e] + SparseArrays
  [10745b16] + Statistics
  [8dfed614] + Test
  [cf7118a7] + UUIDs
  [4ec0a83e] + Unicode
[ Info: Assigning UUID 0bd2840f-3225-55fc-890c-734c837bc738 to guUh9
 Resolving package versions...
  Updating `~/.julia/packages/PyCall/guUh9/aot/Project.toml`
  [0bd2840f] + guUh9 v0.0.0 [`~/.julia/packages/PyCall/guUh9`]
  Updating `~/.julia/packages/PyCall/guUh9/aot/Manifest.toml`
  [8f4d0f93] + Conda v1.2.0
  [682c06a0] + JSON v0.20.0
  [81def892] + VersionParsing v1.1.3
  [0bd2840f] + guUh9 v0.0.0 [`~/.julia/packages/PyCall/guUh9`]
ERROR: LoadError: The following package names could not be resolved:
 * PyCall (not found in project or manifest)
Please specify by known `name=uuid`.
Stacktrace:
 [1] pkgerror(::String) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/Types.jl:120
 [2] #ensure_resolved#72(::Bool, ::Function, ::Pkg.Types.EnvCache, ::Array{Pkg.Types.PackageSpec,1}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/Types.jl:1010
 [3] ensure_resolved at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/Types.jl:981 [inlined]
 [4] #build#59(::Bool, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::Pkg.Types.Context, ::Array{Pkg.Types.PackageSpec,1}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/API.jl:370
 [5] build at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/API.jl:352 [inlined]
 [6] #build#58 at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/API.jl:350 [inlined]
 [7] build at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/API.jl:350 [inlined]
 [8] #build#55 at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/API.jl:347 [inlined]
 [9] build(::String) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/API.jl:347
 [10] top-level scope at none:0
 [11] include at ./boot.jl:326 [inlined]
 [12] include_relative(::Module, ::String) at ./loading.jl:1038
 [13] include(::Module, ::String) at ./sysimg.jl:29
 [14] exec_options(::Base.JLOptions) at ./client.jl:267
 [15] _start() at ./client.jl:436
in expression starting at /home/ubuntu/.julia/packages/PyCall/guUh9/aot/compile.jl:11
```

This is because `aot` directory isn't directly under `PyCall` directory: `~/.julia/packages/PyCall/xxx/aot` not `~/.julia/packages/PyCall/aot`