### PR TITLE
Support calling PyCall.npyinitialize() during sysimage compilation

### DIFF
--- a/aot/precompile.jl
+++ b/aot/precompile.jl
@@ -14,3 +14,15 @@ isdefined(MacroTools, :__init__) && MacroTools.__init__()
 using PyCall
 PyCall.__init__()
 PyCall.pyimport("sys")[:executable]
+
+has_numpy = try
+    PyCall.pyimport("numpy")
+    true
+catch
+    false
+end
+if has_numpy
+    # Invoke numpy support (which mutates various states in PyCall) to
+    # test that it does not introduce any run-time bugs:
+    PyCall.npyinitialize()
+end

--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -131,6 +131,7 @@ function __init__()
     _finalized[] = false
     empty!(_namespaces)
     empty!(eventloops)
+    global npy_initialized = false
     empty!(npy_api)
     empty!(pycall_gc)
     empty!(pyexc)


### PR DESCRIPTION
In PR #651, I introduced code to empty `npy_api` in `__init__` but forgot to reset `npy_initialized`.  This introduces a bug if `npyinitialize` is called during sysimage compilation (`--output-o` mode) because the main body of `npyinitialize` is not run at run-time.

I checked that [undoing the fix](https://github.com/tkf/PyCall.jl/commit/25ff0ad3b9c1b44c55b20072c543ec1b385dafc7) breaks [the AOT compilation test](https://travis-ci.com/tkf/PyCall.jl/jobs/201289387).
