### PR TITLE
propertynames for PyNULL

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -305,8 +305,7 @@ end
 
 getproperty(o::PyObject, s::Symbol) = convert(PyAny, getproperty(o, String(s)))
 
-propertynames(o::PyObject) = map(x->Symbol(first(x)),
-                                pycall(inspect."getmembers", PyObject, o))
+propertynames(o::PyObject) = ispynull(o) ? Symbol[] : map(x->Symbol(first(x)), pycall(inspect."getmembers", PyObject, o))
 
 # avoiding method ambiguity
 setproperty!(o::PyObject, s::Symbol, v) = _setproperty!(o,s,v)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -345,6 +345,7 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
     @test ispynull(PyNULL())
     @test !ispynull(PyObject(3))
     @test ispynull(pydecref(PyObject(3)))
+    @test isempty(propertynames(PyNULL()))
 
     ex = try
         pyimport("s p a m")


### PR DESCRIPTION
it seems to get seg-faulted so easily on the `PyNULL` object.
this PR checks `ispynull(o)` in `propertynames(o::PyObject)`.

```
julia> using PyCall: PyNULL

julia> o = PyNULL()
PyObject NULL

julia> o.<TAB>
signal (11): Segmentation fault: 11
in expression starting at no file:0
_PyEval_EvalCodeWithName at /Library/Frameworks/Python.framework/Versions/3.7/Python (unknown line)
_PyFunction_FastCallDict at /Library/Frameworks/Python.framework/Versions/3.7/Python (unknown line)
macro expansion at /Users/wookyoung/.julia/dev/PyCall/src/exception.jl:93 [inlined]
#110 at /Users/wookyoung/.julia/dev/PyCall/src/pyfncall.jl:43 [inlined]
disable_sigint at ./c.jl:446 [inlined]
__pycall! at /Users/wookyoung/.julia/dev/PyCall/src/pyfncall.jl:42 [inlined]
_pycall! at /Users/wookyoung/.julia/dev/PyCall/src/pyfncall.jl:29
_pycall! at /Users/wookyoung/.julia/dev/PyCall/src/pyfncall.jl:11 [inlined]
#pycall#115 at /Users/wookyoung/.julia/dev/PyCall/src/pyfncall.jl:80 [inlined]
pycall at /Users/wookyoung/.julia/dev/PyCall/src/pyfncall.jl:80 [inlined]
propertynames at /Users/wookyoung/.julia/dev/PyCall/src/PyCall.jl:308
propertynames at ./reflection.jl:1205
unknown function (ip: 0x127894057)
jl_fptr_trampoline at /Users/julia/buildbot/worker/package_macos64/build/src/gf.c:1842
complete_symbol at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/REPL/src/REPLCompletions.jl:148
completions at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/REPL/src/REPLCompletions.jl:714
unknown function (ip: 0x12788aaae)
completions at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/REPL/src/REPLCompletions.jl:580
complete_line at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/REPL/src/REPL.jl:349
complete_line at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/REPL/src/LineEdit.jl:322
unknown function (ip: 0x127884904)
complete_line at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/REPL/src/LineEdit.jl:313
edit_tab at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/REPL/src/LineEdit.jl:1954
unknown function (ip: 0x1278831b5)
edit_tab at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/REPL/src/LineEdit.jl:1954 [inlined]
#108 at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/REPL/src/LineEdit.jl:1995
jl_apply at /Users/julia/buildbot/worker/package_macos64/build/src/./julia.h:1571 [inlined]
jl_f__apply at /Users/julia/buildbot/worker/package_macos64/build/src/builtins.c:556
jl_f__apply_latest at /Users/julia/buildbot/worker/package_macos64/build/src/builtins.c:594
#invokelatest#1 at ./essentials.jl:742 [inlined]
invokelatest at ./essentials.jl:741 [inlined]
#27 at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/REPL/src/LineEdit.jl:1324
prompt! at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/REPL/src/LineEdit.jl:2365
run_interface at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/REPL/src/LineEdit.jl:2268
run_frontend at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/REPL/src/REPL.jl:1035
run_repl at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/REPL/src/REPL.jl:192
#734 at ./client.jl:362
jfptr_#734_6073.clone_1 at /Applications/Julia-1.1.1.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
jl_apply at /Users/julia/buildbot/worker/package_macos64/build/src/./julia.h:1571 [inlined]
jl_f__apply at /Users/julia/buildbot/worker/package_macos64/build/src/builtins.c:556
jl_f__apply_latest at /Users/julia/buildbot/worker/package_macos64/build/src/builtins.c:594
#invokelatest#1 at ./essentials.jl:742 [inlined]
invokelatest at ./essentials.jl:741 [inlined]
run_main_repl at ./client.jl:346
exec_options at ./client.jl:284
_start at ./client.jl:436
true_main at /Applications/Julia-1.1.1.app/Contents/Resources/julia/bin/julia (unknown line)
main at /Applications/Julia-1.1.1.app/Contents/Resources/julia/bin/julia (unknown line)
Allocations: 13030556 (Pool: 13028692; Big: 1864); GC: 27
[1]    19246 segmentation fault  /Applications/Julia-1.1.1.app/Contents/Resources/julia/bin/julia --color=yes
```