### PR TITLE
Throw an error instead of just creating one

### DIFF
--- a/src/gc.jl
+++ b/src/gc.jl
@@ -29,7 +29,7 @@ const weakref_callback_meth = Ref{PyMethodDef}()
 function pyembed(po::PyObject, jo::Any)
     # If there's a need to support immutable embedding,
     # the API needs to be changed to return the pointer.
-    isimmutable(jo) && ArgumentError("pyembed: immutable argument not allowed")
+    isimmutable(jo) && throw(ArgumentError("pyembed: immutable argument not allowed"))
     if ispynull(weakref_callback_obj)
         cf = @cfunction(weakref_callback, PyPtr, (PyPtr,PyPtr))
         weakref_callback_meth[] = PyMethodDef("weakref_callback", cf, METH_O)


### PR DESCRIPTION
```jl
julia> function f()
         true && ArgumentError("hi")
         1
       end
f (generic function with 1 method)

julia> f()
1
```