### PR TITLE
Call Random.__init__() manually to fix AOT with Julia 1.3

### DIFF
--- a/aot/precompile.jl
+++ b/aot/precompile.jl
@@ -1,3 +1,6 @@
+using Random
+Random.__init__()
+
 # Activate ./Project.toml.  Excluding `"@v#.#"` from `Base.LOAD_PATH`
 # to make compilation more reproducible.
 using Pkg


### PR DESCRIPTION
(Trying to) Fix the error from AOT compilation test:

```
ERROR: LoadError: LoadError: LoadError: AssertionError: 0 < tid <= length(THREAD_RNGs)
Stacktrace:
 [1] default_rng(::Int64) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Random/src/RNGs.jl:298
 [2] default_rng at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Random/src/RNGs.jl:296 [inlined]
 [3] shuffle!(::Array{Symbol,1}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Random/src/misc.jl:220
 [4] include at ./boot.jl:328 [inlined]
...
```

--- https://travis-ci.org/JuliaPy/PyCall.jl/jobs/585892454#L803-L808