### PR TITLE
Fix `BoundsError` on @pycall without args

### DIFF
--- a/src/pyfncall.jl
+++ b/src/pyfncall.jl
@@ -99,7 +99,7 @@ macro pycall(ex)
     end
     func = ex.args[1].args[1]
     args, kwargs = ex.args[1].args[2:end], []
-    if isexpr(args[1],:parameters)
+    if !isempty(args) && isexpr(args[1],:parameters)
         kwargs, args = args[1], args[2:end]
     end
     T = ex.args[2]


### PR DESCRIPTION
This fixes a `BoundsError` occurring when using the `@pycall f(a::A...)::T` macro on functions without arguments.

Before:
```julia-repl
julia> using PyCall

julia> py"""
       def a():
           return 64

       def b(a, b):
           return a + b

       def c(a, *, b, c=3):
           return a + b *c
       """

julia> a, b, c = py"a, b, c"
(PyObject <function a at 0x130f76830>, PyObject <function b at 0x130f76950>, PyObject <function c at 0x130f769e0>)

julia> @pycall a()::Int64
ERROR: LoadError: BoundsError: attempt to access 0-element Array{Any,1} at index [1]
Stacktrace:
 [1] getindex(::Array{Any,1}, ::Int64) at ./array.jl:728
 [2] @pycall(::LineNumberNode, ::Module, ::Any) at /Users/ath/Development/PyCall.jl/src/pyfncall.jl:102
in expression starting at REPL[4]:1

julia> @pycall b(1, 2)::Int64
3

julia> @pycall c(1, b=2)::Int64
7

julia> @pycall c(1, b=2, c=4)::Int64
9
```

After:
```julia-repl
julia> using PyCall
[ Info: Recompiling stale cache file /Users/ath/.julia/compiled/v1.2/PyCall/GkzkC.ji for PyCall [438e738f-606a-5dbb-bf0a-cddfbfd45ab0]

julia> py"""
       def a():
         return 64

       def b(a, b):
         return a + b

       def c(a, *, b, c=3):
         return a + b *c
       """

julia> a, b, c = py"a, b, c"
(PyObject <function a at 0x12d7629e0>, PyObject <function b at 0x12d762a70>, PyObject <function c at 0x12d762b90>)

julia> @pycall a()::Int64
64

julia> @pycall b(1, 2)::Int64
3

julia> @pycall c(1, b=2)::Int64
7

julia> @pycall c(1, b=2, c=4)::Int64
9
```