### PR TITLE
Be able to use customized pickle lib

### DIFF
--- a/src/serialize.jl
+++ b/src/serialize.jl
@@ -3,8 +3,15 @@ import Serialization: serialize, deserialize
 import Serialization: serialize_type
 
 const _pickle = PyNULL()
+_pickle_libname = PyCall.pyversion.major ≥ 3 ? "pickle" : "cPickle"
 
-pickle() = ispynull(_pickle) ? copy!(_pickle, pyimport(PyCall.pyversion.major ≥ 3 ? "pickle" : "cPickle")) : _pickle
+pickle() = ispynull(_pickle) ? copy!(_pickle, pyimport(_pickle_libname)) : _pickle
+
+function setpicklelib(libname)
+    global _pickle_libname, _pickle
+    _pickle_libname = libname
+    copy!(_pickle, pyimport(_pickle_libname))
+end
 
 function serialize(s::AbstractSerializer, pyo::PyObject)
     serialize_type(s, PyObject)


### PR DESCRIPTION
reference https://discourse.julialang.org/t/can-we-import-dill-in-pycall-rather-than-pickle/32299

before:
```julia
julia> using Distributed

julia> addprocs(2);

julia> @everywhere using PyCall

julia> @everywhere math=pyimport("math")

julia> pmap(x->math.sin(x), [1,2])
ERROR: PyError ($(Expr(:escape, :(ccall(#= /home/lizz/.julia/packages/PyCall/ttONZ/src/pyfncall.jl:44 =# @pysym(:PyObject_Call), PyPtr, (PyPtr, PyPtr, PyPtr), o, pyargsptr, kw))))) <class 'TypeError'>
TypeError("can't pickle module objects")
```

after:
```julia
julia> using Distributed

julia> addprocs(2);

julia> @everywhere using PyCall

julia> @everywhere PyCall.setpicklelib("dill")

julia> @everywhere math=pyimport("math")

julia> pmap(x->math.sin(x), [1,2])
2-element Array{Float64,1}:
 0.8414709848078965
 0.9092974268256817
```