### PR TITLE
Improving find libpython

### DIFF
--- a/deps/find_libpython.py
+++ b/deps/find_libpython.py
@@ -182,8 +182,9 @@ def candidate_names(suffix=SHLIB_SUFFIX):
     sysdata = dict(
         v=sys.version_info,
         # VERSION is X.Y in Linux/macOS and XY in Windows:
-        VERSION=(sysconfig.get_config_var("VERSION") or
-                 "{v.major}.{v.minor}".format(v=sys.version_info)),
+        VERSION=(sysconfig.get_python_version() or
+                 "{v.major}.{v.minor}".format(v=sys.version_info) or
+                 sysconfig.get_config_var("VERSION")),
         ABIFLAGS=(sysconfig.get_config_var("ABIFLAGS") or
                   sysconfig.get_config_var("abiflags") or ""),
     )


### PR DESCRIPTION
Use `sysconfig.get_system_var("VERSION")` as last resort as there is a possibility that it is not updated.

```python
>>> sys.version_info
sys.version_info(major=3, minor=8, micro=0, releaselevel='final', serial=0)
>>> sysconfig.get_config_var("VERSION")
'3.7'
>>> sysconfig.get_python_version()
'3.8'
```
Closes #752 