### PR TITLE
[RFC] Throw a special exceptions in Julia callbacks (Fix #770)

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -862,7 +862,7 @@ if pyversion >= v"3.3"
 else
     function empty!(o::PyObject)
         p = _getproperty(o, "clear")
-        if p != NULL # for dict, set, etc.
+        if p != PyNULL() # for dict, set, etc.
             pydecref(pycall(PyObject(o)."clear", PyObject))
         else
             for i = length(o)-1:-1:0

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -494,7 +494,7 @@ function pyimport(name::AbstractString)
     o = _pyimport(name)
     if ispynull(o)
         if pyerr_occurred()
-            e = PyError("PyImport_ImportModule")
+            e = pyerror("PyImport_ImportModule")
             if pyisinstance(e.val, @pyglobalobjptr(:PyExc_ImportError))
                 # Expand message to help with common user confusions.
                 msg = """
@@ -540,7 +540,7 @@ or alternatively you can use the Conda package directly (via
 `using Conda` followed by `Conda.add` etcetera).
 """
                 end
-                e = PyError(string(e.msg, "\n\n", msg, "\n"), e)
+                e = pyerror(string(e.msg, "\n\n", msg, "\n"), e)
             end
             throw(e)
         else

--- a/src/exception.jl
+++ b/src/exception.jl
@@ -1,8 +1,8 @@
 #########################################################################
 # A wrapper around an error that happened in a Julia callback
 
-struct PyJlError{E<:Exception} <: Exception
-    err::E
+struct PyJlError <: Exception
+    err
     trace
 end
 


### PR DESCRIPTION
This PR tries to address the printing of stack traces in Julia callbacks and fix #770, while also leaving the door open for further improvements.

The problem I wanted to solve is the fact that errors and stack traces thrown by a Julia callback executed by python, such as 
```python
julia> py"$error('I am ugly')"
```
loses formatting when being displayed. 
This is because currently we _render_ the exception to a string when it is thrown, return it to python as a python error, which then is returned to Julia again, and displays it.

This is especially painful in wrapper packages such as Tensorflow.jl, Jax.jl or several others.

In the process formatting is lost. 

My solution:
When a Julia callback throws, don't render the callback immediately. Instead return a custom Error type, `PyJlError`, which stores the backtrace.

When control is eventually returned to Julia, check if the python error is wrapping a Julia error. If so, show only the Julia one.

This is compatible with JuliaPy, as the rendering of `PyJlError` is handled by the show method.

Result:
old:
```Julia
julia> using PyCall
julia> py"$error('I am ugly')"
ERROR: PyError ($(Expr(:escape, :(ccall(#= /Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/pyeval.jl:38 =# @pysym(:PyEval_EvalCode), PyPtr, (PyPtr, PyPtr, PyPtr), o, globals, locals))))) <class 'RuntimeError'>
RuntimeError('Julia exception: I am ugly\nStacktrace:\n [1] error(::String) at ./error.jl:33\n [2] #invokelatest#1 at ./essentials.jl:712 [inlined]\n [3] invokelatest(::Any, ::Any) at ./essentials.jl:711\n [4] _pyjlwrap_call(::Function, ::Ptr{PyCall.PyObject_struct}, ::Ptr{PyCall.PyObject_struct}) at /Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/callback.jl:28\n [5] pyjlwrap_call(::Ptr{PyCall.PyObject_struct}, ::Ptr{PyCall.PyObject_struct}, ::Ptr{PyCall.PyObject_struct}) at /Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/callback.jl:49\n [6] macro expansion at /Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/exception.jl:93 [inlined]\n [7] #120 at /Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/pyeval.jl:38 [inlined]\n [8] disable_sigint at ./c.jl:446 [inlined]\n [9] pyeval_(::String, ::PyDict{String,PyObject,true}, ::PyDict{String,PyObject,true}, ::Int64, ::String) at /Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/pyeval.jl:37\n [10] top-level scope at /Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/pyeval.jl:230\n [11] eval(::Module, ::Any) at ./boot.jl:331\n [12] eval_user_input(::Any, ::REPL.REPLBackend) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:86\n [13] run_backend(::REPL.REPLBackend) at /Users/filippovicentini/.julia/packages/Revise/Pcs5V/src/Revise.jl:1073\n [14] top-level scope at none:0\n [15] eval(::Module, ::Any) at ./boot.jl:331\n [16] eval_user_input(::Any, ::REPL.REPLBackend) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:86\n [17] macro expansion at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:118 [inlined]\n [18] (::REPL.var"#26#27"{REPL.REPLBackend})() at ./task.jl:358')
  File "/Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/pyeval.jl", line 1, in <module>
    const Py_single_input = 256  # from Python.h

Stacktrace:
 [1] pyerr_check at /Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/exception.jl:60 [inlined]
 [2] pyerr_check at /Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/exception.jl:64 [inlined]
 [3] _handle_error(::String) at /Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/exception.jl:81
 [4] macro expansion at /Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/exception.jl:95 [inlined]
 [5] #120 at /Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/pyeval.jl:38 [inlined]
 [6] disable_sigint at ./c.jl:446 [inlined]
 [7] pyeval_(::String, ::PyDict{String,PyObject,true}, ::PyDict{String,PyObject,true}, ::Int64, ::String) at /Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/pyeval.jl:37
 [8] top-level scope at /Users/filippovicentini/.julia/packages/PyCall/zqDXB/src/pyeval.jl:230
 [9] eval(::Module, ::Any) at ./boot.jl:331
 [10] eval_user_input(::Any, ::REPL.REPLBackend) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:86
 [11] run_backend(::REPL.REPLBackend) at /Users/filippovicentini/.julia/packages/Revise/Pcs5V/src/Revise.jl:1073
 [12] top-level scope at none:0
```

new:
```Julia
julia> py"$error('I am ugly')"
ERROR: An error occured in a Julia function called from Python
I am ugly
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] #invokelatest#1 at ./essentials.jl:712 [inlined]
 [3] invokelatest(::Any, ::Any) at ./essentials.jl:711
 [4] _pyjlwrap_call(::Function, ::Ptr{PyCall.PyObject_struct}, ::Ptr{PyCall.PyObject_struct}) at /Users/filippovicentini/.julia/dev/PyCall/src/callback.jl:28
 [5] pyjlwrap_call(::Ptr{PyCall.PyObject_struct}, ::Ptr{PyCall.PyObject_struct}, ::Ptr{PyCall.PyObject_struct}) at /Users/filippovicentini/.julia/dev/PyCall/src/callback.jl:49
 [6] macro expansion at /Users/filippovicentini/.julia/dev/PyCall/src/exception.jl:117 [inlined]
 [7] #120 at /Users/filippovicentini/.julia/dev/PyCall/src/pyeval.jl:38 [inlined]
 [8] disable_sigint at ./c.jl:446 [inlined]
 [9] pyeval_(::String, ::PyDict{String,PyObject,true}, ::PyDict{String,PyObject,true}, ::Int64, ::String) at /Users/filippovicentini/.julia/dev/PyCall/src/pyeval.jl:37
 [10] top-level scope at /Users/filippovicentini/.julia/dev/PyCall/src/pyeval.jl:230
 [11] eval(::Module, ::Any) at ./boot.jl:331
 [12] eval_user_input(::Any, ::REPL.REPLBackend) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:86
 [13] run_backend(::REPL.REPLBackend) at /Users/filippovicentini/.julia/packages/Revise/Pcs5V/src/Revise.jl:1073
 [14] top-level scope at none:0
 [15] eval(::Module, ::Any) at ./boot.jl:331
 [16] eval_user_input(::Any, ::REPL.REPLBackend) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:86
 [17] macro expansion at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:118 [inlined]
 [18] (::REPL.var"#26#27"{REPL.REPLBackend})() at ./task.jl:358
Stacktrace:
 [1] pyerr_check at /Users/filippovicentini/.julia/dev/PyCall/src/exception.jl:84 [inlined]
 [2] pyerr_check at /Users/filippovicentini/.julia/dev/PyCall/src/exception.jl:88 [inlined]
 [3] _handle_error(::String) at /Users/filippovicentini/.julia/dev/PyCall/src/exception.jl:105
 [4] macro expansion at /Users/filippovicentini/.julia/dev/PyCall/src/exception.jl:119 [inlined]
 [5] #120 at /Users/filippovicentini/.julia/dev/PyCall/src/pyeval.jl:38 [inlined]
 [6] disable_sigint at ./c.jl:446 [inlined]
 [7] pyeval_(::String, ::PyDict{String,PyObject,true}, ::PyDict{String,PyObject,true}, ::Int64, ::String) at /Users/filippovicentini/.julia/dev/PyCall/src/pyeval.jl:37
 [8] top-level scope at /Users/filippovicentini/.julia/dev/PyCall/src/pyeval.jl:230
 [9] eval(::Module, ::Any) at ./boot.jl:331
 [10] eval_user_input(::Any, ::REPL.REPLBackend) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:86
 [11] run_backend(::REPL.REPLBackend) at /Users/filippovicentini/.julia/packages/Revise/Pcs5V/src/Revise.jl:1073
 [12] top-level scope at none:0
```