### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ In Julia:
 
     # ENV["PYTHON"] = "/usr/bin/python3.7"           # example for *nix
     Pkg.build("PyCall")
+    
+Julia needs to be re-launched for this change to take effect.
 
 Note also that you will need to re-run `Pkg.build("PyCall")` if your
 `python` program changes significantly (e.g. you switch to a new


### PR DESCRIPTION
Added that Julia needs to be re-launched for the change of ENV["PYTHON"] to take effect. I needed to do so on my Julia 1.5.0 install in Ubuntu 20.04 and it may help newcomers to note this. This is also written explicitly in the error message (and I used the same terminology in my edit):

julia> plt = pyimport("matplotlib.pyplot")
ERROR: PyError (PyImport_ImportModule

The Python package matplotlib.pyplot could not be found by pyimport. Usually this means
that you did not install matplotlib.pyplot in the Python version being used by PyCall.
...
Alternatively, if you want to use a different Python distribution on your
system, such as a system-wide Python (as opposed to the Julia-specific Python),
you can re-configure PyCall with that Python.   As explained in the PyCall
documentation, set ENV["PYTHON"] to the path/name of the python executable
you want to use, run Pkg.build("PyCall"), and re-launch Julia.