### PR TITLE
Don't try to call `_repr_*_` on a class

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -897,7 +897,10 @@ for (mime, method) in ((MIME"text/html", "_repr_html_"),
             throw(MethodError(show, (io, mime, o)))
         end
         Base.showable(::$mime, o::PyObject) =
-            !ispynull(o) && hasproperty(o, $method) && let meth = o.$method
+            !ispynull(o) &&
+            !pyisinstance(o, @pyglobalobj :PyType_Type) &&  # issue 816
+            hasproperty(o, $method) &&
+            let meth = o.$method
                 !(meth ≛ pynothing[]) &&
                 !(pycall(meth, PyObject) ≛ pynothing[])
             end

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -915,9 +915,15 @@ end
 
 This is a port of `IPython.utils.dir2.get_real_method`:
 https://github.com/ipython/ipython/blob/7.9.0/IPython/utils/dir2.py
+
+For Python 2-era
+https://github.com/ipython/ipython/blob/5.9.0/IPython/utils/dir2.py
 """
 function get_real_method(obj, name)
     ispynull(obj) && return nothing
+    @static if pyversion_build < v"3"
+        pyisinstance(obj, @pyglobalobj :PyType_Type) && return nothing
+    end
 
     canary = try
         trygetproperty(obj, "_ipython_canary_method_should_not_exist_", nothing)

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -896,96 +896,15 @@ for (mime, method) in ((MIME"text/html", "_repr_html_"),
             end
             throw(MethodError(show, (io, mime, o)))
         end
-        function Base.showable(::$mime, o::PyObject)
-            (ispynull(o) || !hasproperty(o, $method)) && return false
-            meth = o.$method
-            _pyapplicable(meth, 0) || return false
-            return !(pycall(meth, PyObject) ≛ pynothing[])
-        end
-    end
-end
-
-"""
-    _pyapplicable(o::PyObject, nargs::Integer) :: Bool
-
-Check if Python object `o` is callable with `nargs` arguments.
-"""
-function _pyapplicable(o::PyObject, nargs::Integer)
-    ccall((@pysym :PyCallable_Check), Cint, (PyPtr,), o) == 1 || return false
-    ran = _posargs_range(o)
-    ran === nothing && return false
-    return nargs in ran
-end
-
-function _posargs_range_py3(o::PyObject)
-    # Using `inspect.signature` so that it can handle (some?) methods
-    # implemented in C such as `int.as_integer_ratio` vs
-    # `(1).as_integer_ratio`.
-    signature = try
-        pycall(inspect."signature", PyObject, o)
-    catch err
-        if err isa PyError && (
-            pyisinstance(err.val, @pyglobalobjptr :PyExc_TypeError) ||
-            pyisinstance(err.val, @pyglobalobjptr :PyExc_ValueError)
-        )
-            return nothing
-        end
-        throw()
-    end
-    POSITIONAL_ONLY = inspect."Parameter"."POSITIONAL_ONLY"
-    POSITIONAL_OR_KEYWORD = inspect."Parameter"."POSITIONAL_OR_KEYWORD"
-    VAR_POSITIONAL = inspect."Parameter"."VAR_POSITIONAL"
-    param_empty = inspect."Parameter"."empty"
-    params = pycall(signature."parameters"."values", PyObject)
-    amin = 0
-    amax = 0
-    has_varargs = false
-    for (i, x) in enumerate(PyIterator(params))
-        k = x."kind"
-        if k ≛ POSITIONAL_ONLY || k ≛ POSITIONAL_OR_KEYWORD
-            if x."default" ≛ param_empty
-                amin = amax = i
-            else
-                amax = i
+        Base.showable(::$mime, o::PyObject) =
+            !ispynull(o) &&
+            !pyisinstance(o, @pyglobalobj :PyType_Type) &&  # issue 816
+            hasproperty(o, $method) &&
+            let meth = o.$method
+                !(meth ≛ pynothing[]) &&
+                !(pycall(meth, PyObject) ≛ pynothing[])
             end
-        elseif k ≛ VAR_POSITIONAL
-            has_varargs = true
-        end
     end
-    amax = has_varargs ? typemax(Int) : amax
-    return amin:amax
-end
-
-function _posargs_range_py2(o::PyObject)
-    spec = try
-        pycall(inspect."getargspec", PyObject, o)
-    catch err
-        if err isa PyError && (
-            pyisinstance(err.val, @pyglobalobjptr :PyExc_TypeError) ||
-            pyisinstance(err.val, @pyglobalobjptr :PyExc_ValueError)
-        )
-            return nothing
-        end
-        throw()
-    end
-    args = get(spec, PyObject, 0, nothing)
-    varargs = get(spec, PyObject, 1, nothing)
-    defaults = get(spec, PyObject, 3, nothing)
-    (args === nothing || varargs === nothing || defaults === nothing) && return nothing
-    ndefaults = defaults ≛ pynothing[] ? 0 : length(defaults)
-    nargs = length(args)
-    if pycall(inspect."ismethod", Bool, o) && !pycall
-        nargs -= 1
-    end
-    amin = max(0, nargs - ndefaults)
-    amax = varargs ≛ pynothing[] ? nargs : typemax(Int)
-    return amin:amax
-end
-
-const _posargs_range = if pyversion < v"3.0.0"
-    _posargs_range_py2
-else
-    _posargs_range_py3
 end
 
 #########################################################################

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -170,6 +170,15 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
 
     # fixme: is there any nontrivial showable test we can do?
     @test !showable("text/html", PyObject(1))
+    @testset "showable on type (#816)" begin
+        py"""
+        class Issue816(object):
+            def _repr_html_(self):
+                return "<h1>Issue816</h1>"
+        """
+        @test showable("text/html", py"Issue816()")
+        @test !showable("text/html", py"Issue816")
+    end
 
     # in Python 3, we need a specific encoding to write strings or bufferize them
     # (http://stackoverflow.com/questions/5471158/typeerror-str-does-not-support-the-buffer-interface)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -175,9 +175,18 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
         class Issue816(object):
             def _repr_html_(self):
                 return "<h1>Issue816</h1>"
+
+        class CallableAsSpecialRepr(object):
+            _repr_html_ = Issue816()._repr_html_
         """
         @test showable("text/html", py"Issue816()")
         @test !showable("text/html", py"Issue816")
+        @test showable("text/html", py"CallableAsSpecialRepr()")
+        if PyCall.pyversion_build < v"3"
+            @test_broken showable("text/html", py"CallableAsSpecialRepr")
+        else
+            @test showable("text/html", py"CallableAsSpecialRepr")
+        end
     end
 
     # in Python 3, we need a specific encoding to write strings or bufferize them

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -731,33 +731,6 @@ def try_call(f):
                        pybuiltin("Exception"))
 end
 
-@testset "_posargs_range" begin
-    funcs = if PyCall.pyversion_build >= v"3"
-        [PyCall._posargs_range_py3, PyCall._posargs_range_py2]
-        else
-        [PyCall._posargs_range_py2]
-    end
-    @testset "$_posargs_range" for _posargs_range in funcs
-        @test _posargs_range(py"None"o) === nothing
-        @test _posargs_range(py"lambda x: None"o) == 1:1
-        @test _posargs_range(py"lambda x, y: None"o) == 2:2
-        @test _posargs_range(py"lambda x, y=1: None"o) == 1:2
-        @test _posargs_range(py"lambda x, *_: None"o) == 1:typemax(Int)
-        @test_broken _posargs_range(py"int"o) == 0:2
-    end
-    if PyCall.pyversion_build >= v"3"
-        io = pyimport("io")
-        @testset "Python 3" begin
-            # `io.BytesIO.fileno` is an example of method implemented in C
-            @test PyCall._posargs_range_py3(io."BytesIO"."fileno") == 1:1
-            @test PyCall._posargs_range_py2(io."BytesIO"."fileno") == 1:1
-            @test PyCall._posargs_range_py3(io."BytesIO"()."fileno") == 0:0
-            @test_broken PyCall._posargs_range_py2(io."BytesIO"()."fileno") == 0:0
-            @test_broken PyCall._posargs_range_py2(io."BytesIO"()."fileno") != 1:1
-        end
-    end
-end
-
 @testset "PyIterator" begin
     arr = [1,2]
     o = PyObject(arr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -731,6 +731,33 @@ def try_call(f):
                        pybuiltin("Exception"))
 end
 
+@testset "_posargs_range" begin
+    funcs = if PyCall.pyversion_build >= v"3"
+        [PyCall._posargs_range_py3, PyCall._posargs_range_py2]
+        else
+        [PyCall._posargs_range_py2]
+    end
+    @testset "$_posargs_range" for _posargs_range in funcs
+        @test _posargs_range(py"None"o) === nothing
+        @test _posargs_range(py"lambda x: None"o) == 1:1
+        @test _posargs_range(py"lambda x, y: None"o) == 2:2
+        @test _posargs_range(py"lambda x, y=1: None"o) == 1:2
+        @test _posargs_range(py"lambda x, *_: None"o) == 1:typemax(Int)
+        @test_broken _posargs_range(py"int"o) == 0:2
+    end
+    if PyCall.pyversion_build >= v"3"
+        io = pyimport("io")
+        @testset "Python 3" begin
+            # `io.BytesIO.fileno` is an example of method implemented in C
+            @test PyCall._posargs_range_py3(io."BytesIO"."fileno") == 1:1
+            @test PyCall._posargs_range_py2(io."BytesIO"."fileno") == 1:1
+            @test PyCall._posargs_range_py3(io."BytesIO"()."fileno") == 0:0
+            @test_broken PyCall._posargs_range_py2(io."BytesIO"()."fileno") == 0:0
+            @test_broken PyCall._posargs_range_py2(io."BytesIO"()."fileno") != 1:1
+        end
+    end
+end
+
 @testset "PyIterator" begin
     arr = [1,2]
     o = PyObject(arr)


### PR DESCRIPTION
fix #816

An MWE

```julia
py"""
class Issue816(object):
    def _repr_html_(self):
        return "<h1>Issue816</h1>"
"""

showable("text/html", py"Issue816()")  # => true
showable("text/html", py"Issue816")  # => throws
```

```
ERROR: PyError ($(Expr(:escape, :(ccall(#= /home/takafumi/.julia/dev/PyCall/src/pyfncall.jl:43 =# @pysym(:PyObject_Call), PyPtr, (PyPtr, PyPtr, PyPtr), o, pyargsptr, kw))))) <class 'TypeError'>
TypeError("_repr_html_() missing 1 required positional argument: 'self'")

Stacktrace:
 [1] pyerr_check at /home/takafumi/.julia/dev/PyCall/src/exception.jl:62 [inlined]
 [2] pyerr_check at /home/takafumi/.julia/dev/PyCall/src/exception.jl:66 [inlined]
 [3] _handle_error(::String) at /home/takafumi/.julia/dev/PyCall/src/exception.jl:83
 [4] macro expansion at /home/takafumi/.julia/dev/PyCall/src/exception.jl:97 [inlined]
 [5] #110 at /home/takafumi/.julia/dev/PyCall/src/pyfncall.jl:43 [inlined]
 [6] disable_sigint at ./c.jl:446 [inlined]
 [7] __pycall! at /home/takafumi/.julia/dev/PyCall/src/pyfncall.jl:42 [inlined]
 [8] _pycall!(::PyObject, ::PyObject, ::Tuple{}, ::Int64, ::Ptr{Nothing}) at /home/takafumi/.julia/dev/PyCall/src/pyfncall.jl:29
 [9] _pycall! at /home/takafumi/.julia/dev/PyCall/src/pyfncall.jl:11 [inlined]
 [10] #pycall#115 at /home/takafumi/.julia/dev/PyCall/src/pyfncall.jl:80 [inlined]
 [11] pycall at /home/takafumi/.julia/dev/PyCall/src/pyfncall.jl:80 [inlined]
 [12] showable(::MIME{Symbol("text/html")}, ::PyObject) at /home/takafumi/.julia/dev/PyCall/src/PyCall.jl:901
 [13] showable(::String, ::Any) at ./multimedia.jl:77
 [14] top-level scope at /home/takafumi/.julia/dev/PyCall/src/pyeval.jl:232
```

The error is due to invoking `Issue816._repr_html_()`. A simple solution seems to just return `false` from `showable("text/html", o)` when `o` is a python type. Although it's probably technically possible to implement `_repr_html_` on classes as well, it's very likely virtually nobody uses it.
