### PR TITLE
fix `PyCall.__init__` when no `__main__` present

### DIFF
--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -232,8 +232,10 @@ function __init__()
     # function (in particular, `self` won't be passed to it). The solution is:
     #    obj[:foo] = jlfun2pyfun(some_julia_function)
     # This is a bit of a kludge, obviously.
-    copy!(jlfun2pyfun,
-          pyeval_("""lambda f: lambda *args, **kwargs: f(*args, **kwargs)"""))
+    copy!(
+        jlfun2pyfun, 
+        pyeval_("lambda f: lambda *args, **kwargs: f(*args, **kwargs)", pynamespace(PyCall), pynamespace(PyCall))
+    )
 
     if !already_inited
         # some modules (e.g. IPython) expect sys.argv to be set


### PR DESCRIPTION
In some environments, `__main__` isn't a module, eg on an [ipyparallel](https://ipyparallel.readthedocs.io/en/latest/) worker `__main__` is a `IPython.core.interactiveshell.DummyMod`, causing PyCall to error on loading because that `pyeval_` is trying to use `__main__` by default. Or worse, if you've compiled a custom sysimage with PyCall (eg for pyjulia), then an error during `__init__` means a segfault. This fixes that. 

Actually, with this PR, I can now run an `ipyparallel` cluster of Python workers calling Julia via pyjulia w/ custom sysimage 🎉

```
$ ipcluster start -n 1 & # start workers
$ ipython
In [1]: import ipyparallel as ipp 
   ...: c = ipp.Client() 
   ...: c.ids                                                                                                                       
Out[1]: [0]

In [2]: %autopx                                                                                                                     
%autopx enabled

In [3]: from julia.api import LibJulia 
   ...: api = LibJulia.load()
   ...: api.sysimage = "sys.so"
   ...: api.init_julia()
   ...: import julia.Main                                                                                                  

In [4]: julia.Main.eval("1+2")                                                                                                      
Out[0:2]: 3
```

Seems a decent bit of people on the pyjulia Issues have been trying do similar stuff (also with multiprocessing and/or Dask), maybe this will be a helpful solution to point out there assuming this PR makes sense to you guys. 