### PR TITLE
AOT testing: Workaround upstream --project + --output-o issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,14 @@ matrix:
         - aot/assert_has_pycall.jl
         - aot/runtests.sh
       after_success: skip
-    - {<<: *test-aot, name: "AOT (Julia: nightly)", julia: nightly}
+    - <<: *test-aot
+      name: "AOT (Julia: nightly)"
+      julia: nightly
+      before_script:
+        # Workaround https://github.com/JuliaLang/julia/issues/37441.
+        # Once it's solved, we can remove the following line (and so
+        # entire `before_script`)
+        - julia --color=yes -e 'using Pkg; pkg"dev ."'
     
 jobs:
  allow_failures:


### PR DESCRIPTION
This patch implements a workaround for https://github.com/JuliaLang/julia/issues/37441 (https://github.com/JuliaPy/PyCall.jl/issues/815); i.e., since the current project is ignored during system image build in Julia 1.6-DEV, we `dev` PyCall into the global environment.

It's a bit ugly but I think it's worth doing this since it would have helped us catching other regressions like https://github.com/JuliaLang/PackageCompiler.jl/issues/445.
