### PR TITLE
Use GitHub Actions to run CI

### DIFF
--- a/.github/workflows/aot.yml
+++ b/.github/workflows/aot.yml
@@ -38,7 +38,10 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.architecture }}
-      - run: julia -e 'using Pkg; pkg"add PackageCompiler@1"'
+
+      # Revert to `@v1` after this PR is merged:
+      # https://github.com/JuliaLang/PackageCompiler.jl/pull/443
+      - run: julia -e 'using Pkg; pkg"add PackageCompiler#cb994c72e2087c57ffa4727ef93589e1b98d8a32"'
 
       # Workaround https://github.com/JuliaLang/julia/issues/37441.
       # Once it's solved, we can remove the following line:

--- a/.github/workflows/aot.yml
+++ b/.github/workflows/aot.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.architecture }}
+      - run: julia -e 'using InteractiveUtils; versioninfo()'
 
       # Revert to `@v1` after this PR is merged:
       # https://github.com/JuliaLang/PackageCompiler.jl/pull/443

--- a/.github/workflows/aot.yml
+++ b/.github/workflows/aot.yml
@@ -1,0 +1,49 @@
+name: AOT test
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test-aot:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        architecture: [x64]
+        python-version: ['3.8']
+        julia-version: ['1.5', 'nightly']
+      fail-fast: false
+    env:
+      PYTHON: python${{ matrix.python-version }}
+    name: Test AOT
+      Julia ${{ matrix.julia-version }}
+      Python ${{ matrix.python-version }}
+      ${{ matrix.os }} ${{ matrix.architecture }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
+      - run: python --version
+      - name: Setup julia
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.architecture }}
+      - run: julia -e 'using Pkg; pkg"add PackageCompiler@1"'
+
+      # Workaround https://github.com/JuliaLang/julia/issues/37441.
+      # Once it's solved, we can remove the following line:
+      - run: julia -e 'using Pkg; pkg"dev PyCall"'
+
+      - run: aot/compile.jl
+      - run: aot/assert_has_pycall.jl
+      - run: aot/runtests.sh

--- a/.github/workflows/aot.yml
+++ b/.github/workflows/aot.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.architecture }}
-      - run: julia -e 'using InteractiveUtils; versioninfo()'
+          show-versioninfo: true
 
       # Revert to `@v1` after this PR is merged:
       # https://github.com/JuliaLang/PackageCompiler.jl/pull/443

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.architecture }}
+      - run: julia -e 'using InteractiveUtils; versioninfo()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,0 +1,47 @@
+name: Test with conda
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test-conda:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        architecture: [x64]
+        julia-version: ['1.5']
+        include:
+          - os: windows-latest
+            architecture: x86
+            julia-version: '1.5'
+      fail-fast: false
+    env:
+      PYTHON: ""
+    name: Test
+      Julia ${{ matrix.julia-version }}
+      Conda
+      ${{ matrix.os }} ${{ matrix.architecture }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup julia
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.architecture }}
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ./lcov.info
+          flags: unittests
+          name: codecov-umbrella

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.architecture }}
-      - run: julia -e 'using InteractiveUtils; versioninfo()'
+          show-versioninfo: true
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.architecture }}
-      - run: julia -e 'using InteractiveUtils; versioninfo()'
+          show-versioninfo: true
       - uses: julia-actions/julia-buildpkg@v1
         env:
           PYTHON: python

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -1,0 +1,67 @@
+name: Test with system Python
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test-system:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        architecture: [x64]
+        python-version: ['2.7', '3.8']
+        julia-version: ['1.0', '1.5', 'nightly']
+        include:
+          - os: windows-latest
+            architecture: x86
+            python-version: '3.8'
+            julia-version: '1.5'
+          - os: ubuntu-latest
+            architecture: x64
+            python-version: '3.7'
+            julia-version: '1.5'
+          - os: ubuntu-latest
+            architecture: x64
+            python-version: '3.8'
+            julia-version: '1.4'
+          - os: ubuntu-latest
+            architecture: x64
+            python-version: '3.8'
+            julia-version: '1.3'
+      fail-fast: false
+    name: Test
+      Julia ${{ matrix.julia-version }}
+      Python ${{ matrix.python-version }}
+      ${{ matrix.os }} ${{ matrix.architecture }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
+      - name: Setup julia
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.architecture }}
+      - uses: julia-actions/julia-buildpkg@v1
+        env:
+          PYTHON: python
+      - run: julia test/check_deps_version.jl ${{ matrix.python-version }}
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ./lcov.info
+          flags: unittests
+          name: codecov-umbrella

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.architecture }}
+      - run: julia -e 'using InteractiveUtils; versioninfo()'
       - uses: julia-actions/julia-buildpkg@v1
         env:
           PYTHON: python

--- a/test/check_deps_version.jl
+++ b/test/check_deps_version.jl
@@ -1,0 +1,10 @@
+using Test
+const desired_version = VersionNumber(ARGS[1])
+include("../deps/deps.jl")
+@testset "pyversion_build ≈ $desired_version" begin
+    @test desired_version.major == pyversion_build.major
+    @test desired_version.minor == pyversion_build.minor
+    if desired_version.patch != 0
+        @test desired_version.patch == pyversion_build.patch
+    end
+end

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -7,6 +7,8 @@ using Test
 
 @testset "find_libpython" begin
     for python in ["python", "python2", "python3"]
+        # TODO: In Windows, word size should also be checked.
+        Sys.iswindows() && break
         if Sys.which(python) === nothing
             @info "$python not available; skipping test"
         else


### PR DESCRIPTION
I've been using GitHub Actions in PyJulia for a while and it's been working nicely. The best part of it is that we don't need OS-specific configurations and also Python on macOS just works. It's also nice that we don't need to click through pages to find out the failing combination.

Since travis-ci.org will be closed down on December 31, 2020, maybe it's a good opportunity to move to GitHub Actions? (Although migration to travis-ci.com is another option.)

https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom?e=%5BUNIQID%5D
https://docs.travis-ci.com/user/migrate/open-source-repository-migration

Some notes:

* I separated out conda and AOT tests from the system Python tests. Although we can save ~20 lines if we combine system and conda Python tests, I think it's cleaner to separate them. Also, re-running test is less time-consuming this way (GitHub Actions only support re-running the entire matrix).
* This PR includes a workaround as in #823 (#815).

This PR does not disable Travis and AppVeyor yet. I think it's safe to run all of them for a while to make sure that this setup works. But I'm OK with removing them in this PR as well.
