### PR TITLE
Skip test_venv.jl and test_build.jl in PkgEval

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -786,5 +786,7 @@ end
 
 include("test_pyfncall.jl")
 include("testpybuffer.jl")
-include("test_venv.jl")
-include("test_build.jl")
+if lowercase(get(ENV, "JULIA_PKGEVAL", "false")) != "true"
+    include("test_venv.jl")
+    include("test_build.jl")
+end


### PR DESCRIPTION
close #812

It would be nice to make these tests more robust. But, for now, I think just skipping them in PkgEval is a good option.