### PR TITLE
Install Numpy on AOT test

### DIFF
--- a/.github/workflows/aot.yml
+++ b/.github/workflows/aot.yml
@@ -33,6 +33,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
       - run: python --version
+      - run: python -m pip install --user numpy
       - name: Setup julia
         uses: julia-actions/setup-julia@v1
         with:


### PR DESCRIPTION
I'm not sure why #831 did not catch this but AOT test fails because of missing Numpy
https://github.com/JuliaPy/PyCall.jl/runs/1167697076#step:10:44

This PR fixes it.
