### PR TITLE
Fix get_real_method; don't use pyversion_build

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PyCall"
 uuid = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 authors = ["Steven G. Johnson <stevenj@mit.edu>", "Yichao Yu <yyc1992@gmail.com>", "Takafumi Arakaki <aka.tkf@gmail.com>", "Simon Kornblith <simon@simonster.com>", "Páll Haraldsson <Pall.Haraldsson@gmail.com>", "Jon Malmaud <malmaud@gmail.com>", "Jake Bolewski <jakebolewski@gmail.com>", "Keno Fischer <keno@alumni.harvard.edu>", "Joel Mason <jobba1@hotmail.com>", "Jameson Nash <vtjnash@gmail.com>", "The JuliaPy development team"]
-version = "1.92.0"
+version = "1.92.1"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -921,7 +921,7 @@ https://github.com/ipython/ipython/blob/5.9.0/IPython/utils/dir2.py
 """
 function get_real_method(obj, name)
     ispynull(obj) && return nothing
-    @static if pyversion_build < v"3"
+    @static if pyversion < v"3"
         pyisinstance(obj, @pyglobalobj :PyType_Type) && return nothing
     end
 


### PR DESCRIPTION
I should've used `pyversion` instead of `pyversion_build` so that it works in PyJulia mode.

close https://github.com/JuliaPy/pyjulia/issues/424

@stevengj Can we release 1.92.1 just after merging this PR?  I incremented the version in Project.toml.