### PR TITLE
Prettyerrors

### DIFF
--- a/src/exception.jl
+++ b/src/exception.jl
@@ -41,6 +41,18 @@ function pystr_nofail(o::PyObject)
     end
 end
 
+function Base.showerror(io::IO, e::PyError)
+    println(io, "PyError:\n", pystr_nofail(e.val))
+    if !ispynull(e.traceback)
+        o = pycall(format_traceback, PyObject, e.traceback)
+        if !ispynull(o)
+            for s in PyVector{AbstractString}(o)
+                print(io, s)
+            end
+        end
+    end
+end
+
 function show(io::IO, e::PyError)
     print(io, "PyError",
           isempty(e.msg) ? e.msg : string(" (",e.msg,")"),
@@ -48,7 +60,7 @@ function show(io::IO, e::PyError)
     if ispynull(e.T)
         println(io, "None")
     else
-        println(io, pystring(e.T), "\n", pystr_nofail(e.val))
+        println(io, pystring(e.T), "\n", pystring(e.val))
     end
 
     if !ispynull(e.traceback)


### PR DESCRIPTION
On master the following snippet:
```julia
using PyCall
py"""
def raise_multi_line_error():
    raise Exception("1\n2\n3\n4\n")
"""
py"raise_multi_line_error"()
```
gives
```
ERROR: LoadError: PyError ($(Expr(:escape, :(ccall(#= /home/jan/.julia/dev/PyCall/src/pyfncall.jl:43
 =# @pysym(:PyObject_Call), PyPtr, (PyPtr, PyPtr, PyPtr), o, pyargsptr, kw))))) <class 'Exception'>
Exception('1\n2\n3\n4\n')
  File "/home/jan/.julia/dev/PyCall/src/pyeval.jl", line 2, in raise_multi_line_error
    const Py_file_input = 257
```
This is hard to read. See also #843 . With this PR it becomes:
```
ERROR: LoadError: PyError:
1
2
3
4

  File "/home/jan/.julia/dev/PyCall/src/pyeval.jl", line 2, in raise_multi_line_error
    const Py_file_input = 257
```