### PR TITLE
Test on Python 3.9

### DIFF
--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -18,24 +18,24 @@ jobs:
           - macos-latest
           - windows-latest
         architecture: [x64]
-        python-version: ['2.7', '3.8']
+        python-version: ['2.7', '3.9']
         julia-version: ['1.0', '1.5', 'nightly']
         include:
           - os: windows-latest
             architecture: x86
-            python-version: '3.8'
+            python-version: '3.9'
             julia-version: '1.5'
           - os: ubuntu-latest
             architecture: x64
-            python-version: '3.7'
+            python-version: '3.9'
             julia-version: '1.5'
           - os: ubuntu-latest
             architecture: x64
-            python-version: '3.8'
+            python-version: '3.9'
             julia-version: '1.4'
           - os: ubuntu-latest
             architecture: x64
-            python-version: '3.8'
+            python-version: '3.9'
             julia-version: '1.3'
       fail-fast: false
     name: Test


### PR DESCRIPTION
FYI: It's out, not sure if premature to test and ok to override 3.8 test. [There's some new stuff in 3.9, regarding e.g. Dicts and they caught up with us/Unicode. Nothing that I think should be a problem.]

Another FYI: I noticed at pybind11 "Python 3.9.0 bug workaround implemented" (and better support for C++20)
https://github.com/pybind/pybind11/releases/tag/v2.6.0rc2

I guess this doesn't affect PyCall (or pyjulia?), those calling Python code shouldn't care, if a problem indirectly then pybind11 would take care of that.