### PR TITLE
Fix tests, Core.TypeofVararg for Julia 1.7 and AOT

### DIFF
--- a/.github/workflows/aot.yml
+++ b/.github/workflows/aot.yml
@@ -41,13 +41,7 @@ jobs:
           arch: ${{ matrix.architecture }}
           show-versioninfo: true
 
-      # Revert to `@v1` after this PR is merged:
-      # https://github.com/JuliaLang/PackageCompiler.jl/pull/443
-      - run: julia -e 'using Pkg; pkg"add PackageCompiler#cb994c72e2087c57ffa4727ef93589e1b98d8a32"'
-
-      # Workaround https://github.com/JuliaLang/julia/issues/37441.
-      # Once it's solved, we can remove the following line:
-      - run: julia -e 'using Pkg; pkg"dev PyCall"'
+      - run: julia -e 'using Pkg; pkg"add PackageCompiler@v1"'
 
       - run: aot/compile.jl
       - run: aot/assert_has_pycall.jl

--- a/aot/runtests.sh
+++ b/aot/runtests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 thisdir="$(dirname "${BASH_SOURCE[0]}")"
-exec "$thisdir/julia.sh" --startup-file=no --color=yes -e '
+exec "$thisdir/julia.sh" --startup-file=no --color=yes --project=$thisdir -e '
 using Pkg
 Pkg.test("PyCall")
 '

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -170,7 +170,10 @@ function pyany_toany(T::Type)
 end
 pyany_toany(::Type{PyAny}) = Any
 pyany_toany(t::Type{T}) where {T<:Tuple} = Tuple{map(pyany_toany, t.types)...}
-
+@static if isdefined(Core, :TypeofVararg) # VERSION >= v"1.7.0-DEV.77"
+    # Core.TypeofVararg introduced in https://github.com/JuliaLang/julia/pull/38136
+    pyany_toany(T::Core.TypeofVararg) = T === Vararg{PyAny} ? Vararg{Any} : T
+end
 # PyAny acts like Any for conversions, except for converting PyObject (below)
 convert(::Type{PyAny}, x) = x
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -172,7 +172,7 @@ pyany_toany(::Type{PyAny}) = Any
 pyany_toany(t::Type{T}) where {T<:Tuple} = Tuple{map(pyany_toany, t.types)...}
 @static if isdefined(Core, :TypeofVararg) # VERSION >= v"1.7.0-DEV.77"
     # Core.TypeofVararg introduced in https://github.com/JuliaLang/julia/pull/38136
-    pyany_toany(T::Core.TypeofVararg) = T === Vararg{PyAny} ? Vararg{Any} : T
+    pyany_toany(T::typeof(Vararg)) = T === Vararg{PyAny} ? Vararg{Any} : T
 end
 # PyAny acts like Any for conversions, except for converting PyObject (below)
 convert(::Type{PyAny}, x) = x


### PR DESCRIPTION
I extracted this commit from the "transpose_and_slice" branch to focus on fixing the tests and AOT now that several issues have been resolved.