### PR TITLE
Use dir instead of getmembers

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -318,7 +318,8 @@ end
 
 function propertynames(o::PyObject)
     ispynull(o) && return Symbol[]
-    return convert(Vector{Symbol}, ccall((@pysym :PyObject_Dir), PyObject, (PyPtr,), o))
+    names = @pycheckn ccall((@pysym :PyObject_Dir), PyObject, (PyPtr,), o)
+    return convert(Vector{Symbol}, names)
 end
 
 # avoiding method ambiguity

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -370,7 +370,7 @@ hasproperty(o::PyObject, s::AbstractString) = pyhasproperty(o, s)
 
 #########################################################################
 
-keys(o::PyObject) = convert(Vector{Symbol}, ccall((@pysym :PyObject_Dir), PyObject, (PyPtr,), o))
+@deprecate keys(o::PyObject) propertynames(o)
 
 #########################################################################
 # Create anonymous composite w = pywrap(o) wrapping the object o

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -316,7 +316,7 @@ function trygetproperty(o::PyObject, s::AbstractString, d)
     return p == C_NULL ? d : PyObject(p)
 end
 
-propertynames(o::PyObject) = ispynull(o) ? Symbol[] : map(x->Symbol(first(x)), PyIterator{PyObject}(pycall(inspect."getmembers", PyObject, o)))
+propertynames(o::PyObject) = ispynull(o) ? Symbol[] : map(Symbol, PyIterator{PyObject}(pycall(py"dir", PyObject, o)))
 
 # avoiding method ambiguity
 setproperty!(o::PyObject, s::Symbol, v) = _setproperty!(o,s,v)
@@ -366,8 +366,7 @@ hasproperty(o::PyObject, s::AbstractString) = pyhasproperty(o, s)
 
 #########################################################################
 
-keys(o::PyObject) = Symbol[m[1] for m in pycall(inspect."getmembers",
-                                PyVector{Tuple{Symbol,PyObject}}, o)]
+keys(o::PyObject) = map(Symbol, pycall(py"dir", PyVector{Tuple{Symbol,PyObject}}, o))
 
 #########################################################################
 # Create anonymous composite w = pywrap(o) wrapping the object o

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -316,7 +316,10 @@ function trygetproperty(o::PyObject, s::AbstractString, d)
     return p == C_NULL ? d : PyObject(p)
 end
 
-propertynames(o::PyObject) = ispynull(o) ? Symbol[] : map(Symbol, PyIterator{PyObject}(pycall(py"dir", PyObject, o)))
+function propertynames(o::PyObject)
+    ispynull(o) && return Symbol[]
+    return convert(Vector{Symbol}, ccall((@pysym :PyObject_Dir), PyObject, (PyPtr,), o))
+end
 
 # avoiding method ambiguity
 setproperty!(o::PyObject, s::Symbol, v) = _setproperty!(o,s,v)
@@ -366,7 +369,7 @@ hasproperty(o::PyObject, s::AbstractString) = pyhasproperty(o, s)
 
 #########################################################################
 
-keys(o::PyObject) = map(Symbol, pycall(py"dir", PyVector{Tuple{Symbol,PyObject}}, o))
+keys(o::PyObject) = convert(Vector{Symbol}, ccall((@pysym :PyObject_Dir), PyObject, (PyPtr,), o))
 
 #########################################################################
 # Create anonymous composite w = pywrap(o) wrapping the object o

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -295,15 +295,8 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
     class A:
         class B:
             C = 1
-            D_ = 2
             @property
             def D(self):
-                return self.D_
-            @D.setter
-            def D(self, Dnew):
-                self.D_ = Dnew
-            @property
-            def E(self):
                 raise NotImplementedError
     """
     A = py"A"
@@ -311,18 +304,12 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
     @test getproperty(A, "B") == py"A.B"
     @test :B in propertynames(A)
     @static if VERSION >= v"0.7-"
-        @test :C in propertynames(A.B)
         @test :D in propertynames(A.B)
-        @test :E in propertynames(A.B)
         @test A.B.C == 1
-        @test A.B.D == 2
-        @test_throws PyCall.PyError A.B.E
         @test_throws KeyError A.X
     end
     setproperty!(py"A.B", "C", 2)
     @test py"A.B.C" == 2
-    setproperty!(py"A.B", "D", 3)
-    @test py"A.B.D" == 3
 
     # buffers
     let b = PyCall.PyBuffer(pyutf8("test string"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -295,17 +295,34 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
     class A:
         class B:
             C = 1
+            D_ = 2
+            @property
+            def D(self):
+                return self.D_
+            @D.setter
+            def D(self, Dnew):
+                self.D_ = Dnew
+            @property
+            def E(self):
+                raise NotImplementedError
     """
     A = py"A"
     @test hasproperty(A, "B")
     @test getproperty(A, "B") == py"A.B"
     @test :B in propertynames(A)
     @static if VERSION >= v"0.7-"
+        @test :C in propertynames(A.B)
+        @test :D in propertynames(A.B)
+        @test :E in propertynames(A.B)
         @test A.B.C == 1
+        @test A.B.D == 2
+        @test_throws PyCall.PyError A.B.E
         @test_throws KeyError A.X
     end
     setproperty!(py"A.B", "C", 2)
     @test py"A.B.C" == 2
+    setproperty!(py"A.B", "D", 3)
+    @test py"A.B.D" == 3
 
     # buffers
     let b = PyCall.PyBuffer(pyutf8("test string"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -310,6 +310,7 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
     end
     setproperty!(py"A.B", "C", 2)
     @test py"A.B.C" == 2
+    @test_deprecated keys(A)
 
     # buffers
     let b = PyCall.PyBuffer(pyutf8("test string"))
@@ -321,7 +322,7 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
 
     let o = PyObject(1+2im)
         @test PyCall.hasproperty(o, :real) # replace by Base.hasproperty in the future
-        @test :real in keys(o)
+        @test :real in propertynames(o)
         @test o.real == 1
     end
 


### PR DESCRIPTION
Fixes #857 by using `dir` to get names of properties instead of `getmembers`, which also gets the properties themselves and therefore errors when properties are optional.