### PR TITLE
Make GC more thread-safe

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -85,11 +85,11 @@ end
 # queue to try again later when we'll eventually be on the main thread.
 function _pydecref_eventually(po)
     if Threads.threadid()==1
-        return pydecref(po)
+        pydecref(po)
     else
         finalizer(_pydecref_eventually, po)
-        return nothing
     end
+    return nothing
 end
 
 PyPtr(o::PyObject) = getfield(o, :o)

--- a/src/pybuffer.jl
+++ b/src/pybuffer.jl
@@ -32,7 +32,7 @@ mutable struct PyBuffer
         b = new(Py_buffer(C_NULL, PyPtr_NULL, 0, 0,
                           0, 0, C_NULL, C_NULL, C_NULL, C_NULL,
                           C_NULL, C_NULL, C_NULL))
-        finalizer(pydecref, b)
+        finalizer(_pydecref_eventually, b)
         return b
     end
 end


### PR DESCRIPTION
Here's my maybe naive way to fix #882.

Trying to aquire the GIL from the finalizer led to deadlocks. This is instead basically option 3 from [here](https://docs.julialang.org/en/v1/manual/multi-threading/#Safe-use-of-Finalizers). Tests pass locally and this fixes the original issue, but I'm not an expert so maybe this has other consequences I'm not thinking of. Comments welcome. 