### PR TITLE
Assignment to `exc` in soft scope is ambiguous 

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -651,12 +651,14 @@ function _pywith(EXPR,VAR,TYPE,BLOCK)
                 $(VAR==nothing ? :() : :($(esc(VAR)) = value))
                 $(esc(BLOCK))
             catch err
+                global exc
                 exc = false
                 if !(@pycall exit(mgr, pyimport(:sys).exc_info()...)::Bool)
                     throw(err)
                 end
             end
         finally
+            global exc
             if exc
                 exit(mgr, nothing, nothing, nothing)
             end


### PR DESCRIPTION
Suppress warning:

```
┌ Warning: Assignment to `#6#exc` in soft scope is ambiguous because a global variable by the same name exists: `#6#exc` will be treated as a new local. Disambiguate by using `local #6#exc` to suppress this warning or `global #6#exc` to assign to the existing global variable.
└ @ C:\Users\simon\devel\empty_app\bin\julia\localdepot\packages\PyCall\BD546\src\PyCall.jl:654
```