### PR TITLE
Dict->IdDict in exception types

### DIFF
--- a/src/exception.jl
+++ b/src/exception.jl
@@ -213,7 +213,7 @@ end
 
 function pyraise(e, bt = nothing)
     eT = typeof(e)
-    pyeT = haskey(pyexc::Dict, eT) ? pyexc[eT] : pyexc[Exception]
+    pyeT = haskey(pyexc, eT) ? pyexc[eT] : pyexc[Exception]
     err = PyJlError(e, bt)
     ccall((@pysym :PyErr_SetObject), Cvoid, (PyPtr, PyPtr),
           pyeT, PyObject(err))

--- a/src/io.jl
+++ b/src/io.jl
@@ -11,7 +11,7 @@
 function ioraise(e, bt = nothing)
     if isa(e, MethodError) || isa(e, ErrorException)
         ccall((@pysym :PyErr_SetString), Cvoid, (PyPtr, Cstring),
-              (pyexc::Dict)[PyIOError],
+              pyexc[PyIOError],
               showerror_string(e, bt))
     else
         pyraise(e, bt)


### PR DESCRIPTION
Dicts use extensive specialization and this adds latency.
IdDicts don't and are the go-to associative container
for type-keys.

This one change reduces startup time by ~0.35s: in fresh sessions, with the package already precompiled, and `--startup-file=no`, `master` is

```julia
julia> tstart = time(); using PyCall; time() - tstart
1.188127040863037
```

whereas this branch is

```julia
julia> tstart = time(); using PyCall; time() - tstart
0.8567991256713867
```

