### PR TITLE
Re-enable AOT test with Julia nightly

### DIFF
--- a/.github/workflows/aot.yml
+++ b/.github/workflows/aot.yml
@@ -20,7 +20,7 @@ jobs:
         julia-version:
           - '1.5'
           - '~1.7.0-rc1'
-          # - 'nightly'  # TODO: reenable
+          - 'nightly'
       fail-fast: false
     env:
       PYTHON: python${{ matrix.python-version }}


### PR DESCRIPTION
AOT with nightly was disabled in #930 to workaround this failure

```
┌ Warning: Could not use exact versions of packages in manifest, re-resolving
└ @ Pkg.Operations /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1510
Precompiling project...
  ✓ CompilerSupportLibraries_jll
  ✓ OpenBLAS_jll
  ✓ libblastrampoline_jll
  ✓ MacroTools
  ✓ PyCall
  5 dependencies successfully precompiled in 6 seconds. 4 already precompiled.
  Activating project at `~/.julia/environments/v1.8`
ERROR: Unsatisfiable requirements detected for package OpenBLAS_jll [4536629a]:
 OpenBLAS_jll [4536629a] log:
 ├─possible versions are: 0.3.17 or uninstalled
 └─restricted to versions 0.3.13 by an explicit requirement — no versions left
```

https://github.com/JuliaPy/PyCall.jl/runs/3986291641?check_suite_focus=true#step:9:41

Opening an issue to re-enable this as a reminder.