### PR TITLE
Workaround missing main symbol in Python >= 3.9

### DIFF
--- a/src/startup.jl
+++ b/src/startup.jl
@@ -73,7 +73,7 @@ else
         libpy_handle = proc_handle
         # Now determine the name of the python library that these symbols are from
         some_address_in_libpython = Libdl.dlsym(libpy_handle, :Py_GetVersion)
-        some_address_in_main_exe = Libdl.dlsym(proc_handle, Sys.isapple() ? :_mh_execute_header : :main)
+        some_address_in_main_exe = Libdl.dlsym(proc_handle, Sys.isapple() ? :_mh_execute_header : :_start)
         dlinfo1 = Ref{Dl_info}()
         dlinfo2 = Ref{Dl_info}()
         ccall(:dladdr, Cint, (Ptr{Cvoid}, Ptr{Dl_info}), some_address_in_libpython,


### PR DESCRIPTION

This patch changes `Libdl.dlsym(proc_handle, :main)` to `Libdl.dlsym(proc_handle, :_start)` to fix https://github.com/JuliaPy/pyjulia/issues/459

In Python >= 3.9, `main` cannot be accessed through the process handle (`dlopen(NULL, ...)` ):

```console
$ python3.9 -c 'import ctypes; ctypes.CDLL(None).main'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/arakaki/.pyenv/versions/3.9.7/lib/python3.9/ctypes/__init__.py", line 387, in __getattr__
    func = self.__getitem__(name)
  File "/home/arakaki/.pyenv/versions/3.9.7/lib/python3.9/ctypes/__init__.py", line 392, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
AttributeError: /home/arakaki/.pyenv/versions/3.9.7/bin/python3.9: undefined symbol: main
```

while it has been possible for < 3.9.

```console
$ python3.8 -c 'import ctypes; ctypes.CDLL(None).main'  # no error
```

I'm not sure why this is the case since `python3.9` binary does seem to have `main`:

```console
$ objdump -dC ~/.pyenv/versions/3.9.7/bin/python3.9 | grep -e '<main>' -A5
0000000000000720 <main>:
 720:   e9 db ff ff ff          jmpq   700 <Py_BytesMain@plt>
 725:   66 2e 0f 1f 84 00 00    nopw   %cs:0x0(%rax,%rax,1)
 72c:   00 00 00
 72f:   90                      nop

--
 74d:   48 8d 3d cc ff ff ff    lea    -0x34(%rip),%rdi        # 720 <main>
 754:   ff 15 86 08 20 00       callq  *0x200886(%rip)        # 200fe0 <__libc_start_main@GLIBC_2.2.5>
 75a:   f4                      hlt
 75b:   0f 1f 44 00 00          nopl   0x0(%rax,%rax,1)
```

That said, https://github.com/JuliaPy/pyjulia/issues/459 can now be solved by checking `_start` instead. (Should we check `main` first and then fallback to `_start`?)

A better fix probably is to use Preferences.jl as the build-time option (#835) and get rid of automatic detection. But I wonder if this is good enough for now?

@Keno It'd be great if you can look at this, as you wrote this originally in #419.
