### PR TITLE
Avoid deprecated BLAS.vendor() in MKL conflict check

### DIFF
--- a/src/numpy.jl
+++ b/src/numpy.jl
@@ -67,7 +67,7 @@ function npyinitialize()
     julia_mkl = @static if VERSION < v"1.7"
         LinearAlgebra.BLAS.vendor() === :mkl
     else
-        any(contains("mkl"), getfield.(BLAS.get_config().loaded_libs, :libname))
+        any(contains("mkl"), getfield.(LinearAlgebra.BLAS.get_config().loaded_libs, :libname))
     end
     if julia_mkl && LinearAlgebra.BLAS.BlasInt === Int64 && hasproperty(numpy, "__config__")
         config = numpy."__config__"

--- a/src/numpy.jl
+++ b/src/numpy.jl
@@ -64,7 +64,11 @@ function npyinitialize()
     numpy = pyimport("numpy")
 
     # emit a warning if both Julia and NumPy are linked with MKL (#433)
-    julia_mkl = any(contains("mkl"), getfield.(BLAS.get_config().loaded_libs, :libname))
+    julia_mkl = @static if VERSION < v"1.7"
+        LinearAlgebra.BLAS.vendor() === :mkl
+    else
+        any(contains("mkl"), getfield.(BLAS.get_config().loaded_libs, :libname))
+    end
     if julia_mkl && LinearAlgebra.BLAS.BlasInt === Int64 && hasproperty(numpy, "__config__")
         config = numpy."__config__"
         if hasproperty(config, "blas_opt_info")

--- a/src/numpy.jl
+++ b/src/numpy.jl
@@ -64,8 +64,8 @@ function npyinitialize()
     numpy = pyimport("numpy")
 
     # emit a warning if both Julia and NumPy are linked with MKL (#433)
-    if LinearAlgebra.BLAS.vendor() === :mkl &&
-       LinearAlgebra.BLAS.BlasInt === Int64 && hasproperty(numpy, "__config__")
+    julia_mkl = any(contains("mkl"), getfield.(BLAS.get_config().loaded_libs, :libname))
+    if julia_mkl && LinearAlgebra.BLAS.BlasInt === Int64 && hasproperty(numpy, "__config__")
         config = numpy."__config__"
         if hasproperty(config, "blas_opt_info")
             blaslibs = get(config."blas_opt_info", Vector{String}, "libraries", String[])


### PR DESCRIPTION
Patch as suggested by Carsten Bauer in #922.

---

As discussed in #922, the new BLAS trampoline magic might allow us to avoid this issue altogether, but this is nontrivial, as it would involve loading MKL in two different configurations even if it did work (the libtrampoline author wasn't sure about that either). For now, this avoids the annoying warning every time PyCall is loaded.