### PR TITLE
Fix file path for file generated during the build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ directly to the `libpython` library.  But it finds the location of
 Subsequent builds of PyCall (e.g. when you update the package via
 `Pkg.update`) will use the same Python executable name by default,
 unless you set the `PYTHON` environment variable or delete the file
-`Pkg.dir("PyCall","deps","PYTHON")`.
+`Pkg.dir("PyCall","deps","deps.jl")`.
 
 **Note:** If you use Python
 [virtualenvs](https://docs.python-guide.org/en/latest/dev/virtualenvs/),


### PR DESCRIPTION
The built file is now `Pkg.dir("PyCall","deps","deps.jl")` as discovered in the investigation of https://github.com/JuliaPy/PyCall.jl/issues/952.