### PR TITLE
Python 3.10 is latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ to the path of the `python` (or `python3` etc.) executable and then re-running `
 In Julia:
 
     ENV["PYTHON"] = "... path of the python executable ..."
-    # ENV["PYTHON"] = raw"C:\Python37-x64\python.exe" # example for Windows, "raw" to not have to escape: "C:\\Python37-x64\\python.exe"
+    # ENV["PYTHON"] = raw"C:\Python310-x64\python.exe" # example for Windows, "raw" to not have to escape: "C:\\Python310-x64\\python.exe"
 
-    # ENV["PYTHON"] = "/usr/bin/python3.7"           # example for *nix
+    # ENV["PYTHON"] = "/usr/bin/python3.10"           # example for *nix
     Pkg.build("PyCall")
 
 Note also that you will need to re-run `Pkg.build("PyCall")` if your


### PR DESCRIPTION
I noticed Python 3.6 is EOLed, and was thinking you may not want say you support it (I didn't locate it), nor test it(?) to not waste resources (nor 2.7?). Maybe default to latest version, for Conda/Windows downloads, so people can profit from latest features?

Also there are security issues with all minor release of all 3.10, 3.9 down to 3.7 (documented) and likely 3.6 and 2.7 and older.

I'm not sure, but it seems 2.7 is still tested...

[skip ci]