### PR TITLE
fix getproperty exceptions

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -300,7 +300,7 @@ function _getproperty(o::PyObject, s::Union{AbstractString,Symbol})
     p = ccall((@pysym :PyObject_GetAttrString), PyPtr, (PyPtr, Cstring), o, s)
     if p == C_NULL && pyerr_occurred()
         e = pyerror("PyObject_GetAttrString")
-        if e.T != @pyglobalobjptr(:PyExc_AttributeError)
+        if PyPtr(e.T) != @pyglobalobjptr(:PyExc_AttributeError)
             throw(e)
         end
         pyerr_clear()

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -300,7 +300,7 @@ function _getproperty(o::PyObject, s::Union{AbstractString,Symbol})
     p = ccall((@pysym :PyObject_GetAttrString), PyPtr, (PyPtr, Cstring), o, s)
     if p == C_NULL && pyerr_occurred()
         e = pyerror("PyObject_GetAttrString")
-        if pyisinstance(e.T, @pyglobalobjptr(:PyExc_AttributeError))
+        if !pyisinstance(e.T, @pyglobalobjptr(:PyExc_AttributeError))
             throw(e)
         end
         pyerr_clear()

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -298,7 +298,13 @@ end
 function _getproperty(o::PyObject, s::Union{AbstractString,Symbol})
     ispynull(o) && throw(ArgumentError("ref of NULL PyObject"))
     p = ccall((@pysym :PyObject_GetAttrString), PyPtr, (PyPtr, Cstring), o, s)
-    p == C_NULL && pyerr_clear()
+    if p == C_NULL && pyerr_occurred()
+        e = pyerror("")
+        if e.T.__name__ != "AttributeError"
+            throw(e)
+        end
+        pyerr_clear()
+    end
     return p
 end
 

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -299,7 +299,7 @@ function _getproperty(o::PyObject, s::Union{AbstractString,Symbol})
     ispynull(o) && throw(ArgumentError("ref of NULL PyObject"))
     p = ccall((@pysym :PyObject_GetAttrString), PyPtr, (PyPtr, Cstring), o, s)
     if p == C_NULL && pyerr_occurred()
-        e = pyerror("")
+        e = pyerror("PyObject_GetAttrString")
         if e.T.__name__ != "AttributeError"
             throw(e)
         end

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -300,7 +300,7 @@ function _getproperty(o::PyObject, s::Union{AbstractString,Symbol})
     p = ccall((@pysym :PyObject_GetAttrString), PyPtr, (PyPtr, Cstring), o, s)
     if p == C_NULL && pyerr_occurred()
         e = pyerror("PyObject_GetAttrString")
-        if !pyisinstance(e.T, @pyglobalobjptr(:PyExc_AttributeError))
+        if e.T != @pyglobalobjptr(:PyExc_AttributeError)
             throw(e)
         end
         pyerr_clear()

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -337,7 +337,7 @@ function _setproperty!(o::PyObject, s::Union{Symbol,AbstractString}, v)
     p = ccall((@pysym :PyObject_SetAttrString), Cint, (PyPtr, Cstring, PyPtr), o, s, PyObject(v))
     if p == -1 && pyerr_occurred()
         e = pyerror("PyObject_SetAttrString")
-        if e.T != @pyglobalobjptr(:PyExc_AttributeError)
+        if PyPtr(e.T) != @pyglobalobjptr(:PyExc_AttributeError)
             throw(e)
         end
         pyerr_clear()

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -337,7 +337,7 @@ function _setproperty!(o::PyObject, s::Union{Symbol,AbstractString}, v)
     p = ccall((@pysym :PyObject_SetAttrString), Cint, (PyPtr, Cstring, PyPtr), o, s, PyObject(v))
     if p == -1 && pyerr_occurred()
         e = pyerror("PyObject_SetAttrString")
-        if e.T.__name__ != "AttributeError"
+        if e.T != @pyglobalobjptr(:PyExc_AttributeError)
             throw(e)
         end
         pyerr_clear()

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -300,7 +300,7 @@ function _getproperty(o::PyObject, s::Union{AbstractString,Symbol})
     p = ccall((@pysym :PyObject_GetAttrString), PyPtr, (PyPtr, Cstring), o, s)
     if p == C_NULL && pyerr_occurred()
         e = pyerror("PyObject_GetAttrString")
-        if e.T.__name__ != "AttributeError"
+        if pyisinstance(e.T, @pyglobalobjptr(:PyExc_AttributeError))
             throw(e)
         end
         pyerr_clear()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -829,3 +829,17 @@ end
         @test py"bar2" == 2
     end
 end
+
+@testset "proper exception raised" begin
+    py"""
+    class A:
+        def __getattr__(self, name):
+            if name == "a":
+                raise ValueError(name)
+            else:
+                raise AttributeError()
+    """
+    a = py"A"()
+    @test_throws PyCall.PyError a.a
+    @test_throws KeyError a.b
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -838,8 +838,17 @@ end
                 raise ValueError(name)
             else:
                 raise AttributeError()
+
+        def __setattr__(self, name, value):
+            if value == 0:
+                raise ValueError(value)
+            else:
+                raise AttributeError()
     """
     a = py"A"()
     @test_throws PyCall.PyError a.a
     @test_throws KeyError a.b
+
+    @test_throws PyCall.PyError a.a = 0
+    @test_throws KeyError a.a = 1
 end


### PR DESCRIPTION
this throws KeyError as before when the attribute isn't there (AttributeError in python)
when the attribute is present, but its computation throws a python exception, this PR rethrows it in julia

fixes https://github.com/JuliaPy/PyCall.jl/issues/696