### PR TITLE
fix BoundsError of args[1] when args is empty

### DIFF
--- a/src/pyfncall.jl
+++ b/src/pyfncall.jl
@@ -99,10 +99,9 @@ macro pycall(ex)
     end
     func = ex.args[1].args[1]
     args, kwargs = ex.args[1].args[2:end], []
-    if length(args) > 0
-        if isexpr(args[1],:parameters)
-            kwargs, args = args[1], args[2:end]
-        end
+    if !isempty(args) && isexpr(args[1],:parameters)
+        kwargs, args = args[1], args[2:end]
+    end
     end
     T = ex.args[2]
     :(pycall($(map(esc,[kwargs; func; T; args])...)))

--- a/src/pyfncall.jl
+++ b/src/pyfncall.jl
@@ -99,8 +99,10 @@ macro pycall(ex)
     end
     func = ex.args[1].args[1]
     args, kwargs = ex.args[1].args[2:end], []
-    if isexpr(args[1],:parameters)
-        kwargs, args = args[1], args[2:end]
+    if length(args) > 0
+        if isexpr(args[1],:parameters)
+            kwargs, args = args[1], args[2:end]
+        end
     end
     T = ex.args[2]
     :(pycall($(map(esc,[kwargs; func; T; args])...)))

--- a/src/pyfncall.jl
+++ b/src/pyfncall.jl
@@ -102,7 +102,6 @@ macro pycall(ex)
     if !isempty(args) && isexpr(args[1],:parameters)
         kwargs, args = args[1], args[2:end]
     end
-    end
     T = ex.args[2]
     :(pycall($(map(esc,[kwargs; func; T; args])...)))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -529,6 +529,8 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
 
     # @pycall macro expands correctly
     _pycall = GlobalRef(PyCall,:pycall)
+    @test macroexpand(@__MODULE__, :(@pycall foo()::T)) == :($(_pycall)(foo, T))
+    @test macroexpand(@__MODULE__, :(@pycall foo(; kwargs...)::T)) == :($(_pycall)(foo, T; kwargs...))
     @test macroexpand(@__MODULE__, :(@pycall foo(bar)::T)) == :($(_pycall)(foo, T, bar))
     @test macroexpand(@__MODULE__, :(@pycall foo(bar, args...)::T)) == :($(_pycall)(foo, T, bar, args...))
     @test macroexpand(@__MODULE__, :(@pycall foo(bar; kwargs...)::T)) == :($(_pycall)(foo, T, bar; kwargs...))


### PR DESCRIPTION
if `args` on L101 is empty, then `args[1]` in `isexpr()` would throw `BoundsError: attempt to access 0-element Vector{Any} at index [1]`

```julia
julia> ex = :(f()::Float64)
:(f()::Float64)

julia> args = ex.args[1].args[2:end]
Any[]

julia> args[1]
ERROR: BoundsError: attempt to access 0-element Vector{Any} at index [1]
Stacktrace:
 [1] getindex(A::Vector{Any}, i1::Int64)
   @ Base ./array.jl:924
 [2] top-level scope
   @ REPL[118]:1

```