### PR TITLE
Fix unittests on Windows

### DIFF
--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -85,6 +85,12 @@ jobs:
           PYTHON: python
       - run: julia test/check_deps_version.jl ${{ matrix.python-version }}
       - uses: julia-actions/julia-runtest@v1
+        env:
+          # Windows temp directories break the CI:
+          #  https://github.com/actions/runner-images/issues/712
+          #  so, we use
+          #  https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context
+          _TMP_DIR: ${{ runner.temp }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/test/test_venv.jl
+++ b/test/test_venv.jl
@@ -1,5 +1,16 @@
 using PyCall, Test
 
+"""Gets temp directory, possibly with user-set environment variable"""
+function _mktempdir(parent=nothing; kwargs...)
+    if parent === nothing && haskey(ENV, "_TMP_DIR")
+        return mktempdir(ENV["_TMP_DIR"]; kwargs...)
+    end
+    if parent === nothing
+        parent = tempdir()
+    end
+    return mktempdir(parent; kwargs...)
+end
+
 
 function test_venv_has_python(path)
     newpython = PyCall.python_cmd(venv=path).exec[1]
@@ -57,7 +68,7 @@ end
     elseif Sys.which(pyname) === nothing
         @info "No $pyname command. Skipping the test..."
     else
-        mktempdir() do tmppath
+        _mktempdir() do tmppath
             if PyCall.pyversion.major == 2
                 path = joinpath(tmppath, "kind")
             else
@@ -108,7 +119,7 @@ end
     elseif !success(PyCall.python_cmd(`-c "import venv"`, python=python))
         @info "Skip venv test since venv package is missing."
     else
-        mktempdir() do tmppath
+        _mktempdir() do tmppath
             if PyCall.pyversion.major == 2
                 path = joinpath(tmppath, "kind")
             else

--- a/test/test_venv.jl
+++ b/test/test_venv.jl
@@ -1,14 +1,14 @@
 using PyCall, Test
 
 """Gets temp directory, possibly with user-set environment variable"""
-function _mktempdir(parent=nothing; kwargs...)
+function _mktempdir(f::Function, parent=nothing; kwargs...)
     if parent === nothing && haskey(ENV, "_TMP_DIR")
-        return mktempdir(ENV["_TMP_DIR"]; kwargs...)
+        return mktempdir(f, ENV["_TMP_DIR"]; kwargs...)
     end
     if parent === nothing
         parent = tempdir()
     end
-    return mktempdir(parent; kwargs...)
+    return mktempdir(f, parent; kwargs...)
 end
 
 

--- a/test/test_venv.jl
+++ b/test/test_venv.jl
@@ -46,7 +46,7 @@ function test_venv_activation(path)
         # Marking the test broken in Windows.  It seems that
         # venv copies .dll on Windows and libpython check in
         # PyCall.__init__ detects that.
-        @test_broken begin
+        @test begin
             output = read(jlcmd, String)
             sys_executable, exec_prefix, mod_file = split(output, "\n")
             newpython == sys_executable


### PR DESCRIPTION
The unittests on master are currently failing on Windows ([example](https://github.com/MilesCranmer/PyCall.jl/actions/runs/3606216417/jobs/6077346172)), with the following unexpected pass:

```
 Unexpected Pass
 Expression: begin
    output = read(jlcmd, String)
    (sys_executable, exec_prefix, mod_file) = split(output, "\n")
    newpython == sys_executable
end
 Got correct result, please change to @test if no longer broken.
```

this PR changes `@test_broken` to `@test` as it seems to work now.

Also, this corrects the temporary base directory in the Windows tests to use the one specified by `runner.temp`, rather than that specified by `%TEMP%` which is what `Base.mktempdir()` uses.

(@stevengj this fixes the reason for the failures on #1015)