### PR TITLE
type-stable PyError constructor

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -299,7 +299,7 @@ function _getproperty(o::PyObject, s::Union{AbstractString,Symbol})
     ispynull(o) && throw(ArgumentError("ref of NULL PyObject"))
     p = ccall((@pysym :PyObject_GetAttrString), PyPtr, (PyPtr, Cstring), o, s)
     if p == C_NULL && pyerr_occurred()
-        e = pyerror("PyObject_GetAttrString")
+        e = PyError("PyObject_GetAttrString")
         if PyPtr(e.T) != @pyglobalobjptr(:PyExc_AttributeError)
             throw(e)
         end
@@ -336,7 +336,7 @@ function _setproperty!(o::PyObject, s::Union{Symbol,AbstractString}, v)
     ispynull(o) && throw(ArgumentError("assign of NULL PyObject"))
     p = ccall((@pysym :PyObject_SetAttrString), Cint, (PyPtr, Cstring, PyPtr), o, s, PyObject(v))
     if p == -1 && pyerr_occurred()
-        e = pyerror("PyObject_SetAttrString")
+        e = PyError("PyObject_SetAttrString")
         if PyPtr(e.T) != @pyglobalobjptr(:PyExc_AttributeError)
             throw(e)
         end
@@ -507,7 +507,7 @@ function pyimport(name::AbstractString)
     o = _pyimport(name)
     if ispynull(o)
         if pyerr_occurred()
-            e = pyerror("PyImport_ImportModule")
+            e = PyError("PyImport_ImportModule")
             if pyisinstance(e.val, @pyglobalobjptr(:PyExc_ImportError))
                 # Expand message to help with common user confusions.
                 msg = """
@@ -553,7 +553,7 @@ or alternatively you can use the Conda package directly (via
 `using Conda` followed by `Conda.add` etcetera).
 """
                 end
-                e = pyerror(string(e.msg, "\n\n", msg, "\n"), e)
+                e = PyError(string(e.msg, "\n\n", msg, "\n"), e)
             end
             throw(e)
         else

--- a/test/test_build.jl
+++ b/test/test_build.jl
@@ -4,11 +4,11 @@ include(joinpath(dirname(@__FILE__), "..", "deps", "depsutils.jl"))
 include(joinpath(dirname(@__FILE__), "..", "deps", "buildutils.jl"))
 
 using Test
+using PyCall: python
 
 @testset "find_libpython" begin
-    for python in ["python", "python2", "python3"]
-        # TODO: In Windows, word size should also be checked.
-        Sys.iswindows() && break
+    # TODO: In Windows, word size should also be checked.
+    if !Sys.iswindows()
         if Sys.which(python) === nothing
             @info "$python not available; skipping test"
         else
@@ -37,7 +37,7 @@ using Test
     # Test the case `dlopen` failed to open the library.
     let err, msg
         @test try
-            find_libpython("python"; _dlopen = (_...) -> error("dummy"))
+            find_libpython(python; _dlopen = (_...) -> error("dummy"))
             false
         catch err
             err isa ErrorException


### PR DESCRIPTION
Closes #1020, closes #1021.

Also incidentally fixes `test_build.jl` when `python` is not installed; it should use `PyCall.python`.