### PR TITLE
Urgent: add option to disable numpy install / prevent corruption of conda-forge environments

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 VersionParsing = "81def892-9a0e-5fdd-b105-ffc91e053289"
 
 [compat]
-Conda = "1.0"
+Conda = "1.9"
 MacroTools = "0.4, 0.5"
 VersionParsing = "1.0"
 julia = "1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PyCall"
 uuid = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 authors = ["Steven G. Johnson <stevenj@mit.edu>", "Yichao Yu <yyc1992@gmail.com>", "Takafumi Arakaki <aka.tkf@gmail.com>", "Simon Kornblith <simon@simonster.com>", "Páll Haraldsson <Pall.Haraldsson@gmail.com>", "Jon Malmaud <malmaud@gmail.com>", "Jake Bolewski <jakebolewski@gmail.com>", "Keno Fischer <keno@alumni.harvard.edu>", "Joel Mason <jobba1@hotmail.com>", "Jameson Nash <vtjnash@gmail.com>", "The JuliaPy development team"]
-version = "1.95.1"
+version = "1.95.2"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -75,9 +75,8 @@ try # make sure deps.jl file is removed on error
     end
 
     use_conda = dirname(python) == abspath(Conda.PYTHONDIR)
-    enable_numpy_install = parse(Bool, get(ENV, "PYCALL_INSTALL_NUMPY", "true"))
-    if use_conda && enable_numpy_install
-        Conda.add("numpy")
+    if use_conda
+        Conda.add("numpy"; satisfied_skip_solve=true)
     end
 
     (libpython, libpy_name) = find_libpython(python)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -75,7 +75,8 @@ try # make sure deps.jl file is removed on error
     end
 
     use_conda = dirname(python) == abspath(Conda.PYTHONDIR)
-    if use_conda
+    enable_numpy_install = parse(Bool, get(ENV, "PYCALL_INSTALL_NUMPY", "true"))
+    if use_conda && enable_numpy_install
         Conda.add("numpy")
     end
 


### PR DESCRIPTION
Right now PyCall.jl automatically installs numpy into a conda environment. This install cannot be disabled. If this occurs from within an existing conda environment, it can overwrite the numpy installed by a conda-forge build. This violates the assumptions of conda-forge, and can silently corrupt any conda env that depends on numpy.

This issue was noticed in https://github.com/conda-forge/pysr-feedstock/pull/85, manifesting in this issue: https://github.com/conda-forge/scipy-feedstock/issues/238. We believe this is caused by the line:

https://github.com/JuliaPy/PyCall.jl/blob/bcaba00d1e2c412b2f61d33343ef5a9ab1b9258a/deps/build.jl#L79

This PR enables the `PYCALL_INSTALL_NUMPY` environment flag which can be set to `false` to disable the `Conda.add("numpy")` line and prevent the corruption of a conda env. The default behavior is unchanged if this flag is not set, so this is backwards compatible.

cc @h-vetinari @mkitti @ngam