### PR TITLE
fix depwarn

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PyCall"
 uuid = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 authors = ["Steven G. Johnson <stevenj@mit.edu>", "Yichao Yu <yyc1992@gmail.com>", "Takafumi Arakaki <aka.tkf@gmail.com>", "Simon Kornblith <simon@simonster.com>", "Páll Haraldsson <Pall.Haraldsson@gmail.com>", "Jon Malmaud <malmaud@gmail.com>", "Jake Bolewski <jakebolewski@gmail.com>", "Keno Fischer <keno@alumni.harvard.edu>", "Joel Mason <jobba1@hotmail.com>", "Jameson Nash <vtjnash@gmail.com>", "The JuliaPy development team"]
-version = "1.96.0"
+version = "1.96.1"
 
 [deps]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -983,7 +983,7 @@ const _deepcopy = PyNULL()
 
 function Base.deepcopy_internal(obj::PyObject, stackdict::Base.IdDict)
     haskey(stackdict, obj) && return stackdict[obj]
-    ispynull(_deepcopy) && copy!(_deepcopy, pyimport("copy")["deepcopy"])
+    ispynull(_deepcopy) && copy!(_deepcopy, pyimport("copy")."deepcopy")
     ret =  pycall(_deepcopy, PyObject, obj)
     stackdict[obj] = ret
     ret

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -622,7 +622,7 @@ end
 
 @testset "deepcopy #757" begin
     l = py"[1,2,3]"o
-    l2 = deepcopy(l)
+    l2 = @test_nowarn deepcopy(l)
     @test l == l2
     l2.append(4)
     @test l != l2
@@ -636,7 +636,7 @@ end
             self.b = b
     """
     obj = py"C757(C757(1,2), C757(3,4))"o
-    obj2 = deepcopy(obj)
+    obj2 = @test_nowarn deepcopy(obj)
     @test PyPtr(obj) != PyPtr(obj2) # make sure a new Python object is created
     @test obj.a.a == obj2.a.a
     @test obj.a.b == obj2.a.b
@@ -651,7 +651,7 @@ end
 
     c = py"C757(1,2)"
     obj = S(c, c)
-    obj2 = deepcopy(obj)
+    obj2 = @test_nowarn deepcopy(obj)
     @test obj.a === obj.b
     @test obj2.a === obj2.b
     obj.a.a = 4


### PR DESCRIPTION
This updates deprecated code introduced in https://github.com/JuliaPy/PyCall.jl/pull/1039. We found this since our tests using some operations from PyCall.jl with `@test_nowarn` failed.