### PR TITLE
A few fixes for julia master

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ julia = "1.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [targets]
-test = ["Test"]
+test = ["Test", "REPL"]

--- a/deps/depsutils.jl
+++ b/deps/depsutils.jl
@@ -64,8 +64,10 @@ function _preserveas!(dest::Vector{UInt8}, ::Type{Cstring}, x::AbstractString)
 end
 
 function _preserveas!(dest::Vector{UInt8}, ::Type{Cwstring}, x::AbstractString)
-    s = reinterpret(UInt8, Base.cconvert(Cwstring, x))
-    copyto!(resize!(dest, length(s)), s)
+    s = reinterpret(UInt8, transcode(Cwchar_t, String(x)))
+    len = length(s)
+    copyto!(resize!(dest, len + sizeof(Cwchar_t)), s)
+    dest[len + 1:len + sizeof(Cwchar_t)] .= 0
     return pointer(dest)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using PyCall
 using PyCall: hasproperty
 using Test, Dates, Serialization
+using REPL # for Docs.doc methods
 
 filter(f, itr) = collect(Iterators.filter(f, itr))
 filter(f, d::AbstractDict) = Base.filter(f, d)


### PR DESCRIPTION
1. Fix use of `cconvert(Cwstring)`. This may count as a breakage from base julia but it's a bit of a grey area. It may be argued that the return type for `cconvert` isn't really guaranteed.
2. `Docs.doc` is defined in base but the methods are defined in `REPL`. With `REPL` moved out of the sysimg by default this needs to be loaded explicitly.