### PR TITLE
Fix the stdlib compat entries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,10 +18,10 @@ MacroTools = "0.4, 0.5"
 VersionParsing = "1.0"
 
 julia = "1.4"
-Dates = "1.4"
-Libdl = "1.4"
-LinearAlgebra = "1.4"
-Serialization = "1.4"
+Dates = "<0.0.1, 1"
+Libdl = "<0.0.1, 1"
+LinearAlgebra = "<0.0.1, 1"
+Serialization = "<0.0.1, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Fixes #1064 

Almost all stdlibs should just use a compat entry of `"< 0.0.0, 1"`. So e.g.

```toml
StdlibName = "< 0.0.1, 1"
```

The `SHA` stdlib is an exception, because it should be:
```toml
SHA = "< 0.0.1, 0.7, 1"
```