### PR TITLE
Rename `distutils.sysconfig` to `sysconfig`

### DIFF
--- a/deps/buildutils.jl
+++ b/deps/buildutils.jl
@@ -5,7 +5,7 @@ import Conda, Libdl
 
 pyvar(python::AbstractString, mod::AbstractString, var::AbstractString) = chomp(read(pythonenv(`$python -c "import $mod; print($mod.$(var))"`), String))
 
-pyconfigvar(python::AbstractString, var::AbstractString) = pyvar(python, "distutils.sysconfig", "get_config_var('$(var)')")
+pyconfigvar(python::AbstractString, var::AbstractString) = pyvar(python, "sysconfig", "get_config_var('$(var)')")
 pyconfigvar(python, var, default) = let v = pyconfigvar(python, var)
     v == "None" ? default : v
 end

--- a/deps/buildutils.jl
+++ b/deps/buildutils.jl
@@ -5,7 +5,15 @@ import Conda, Libdl
 
 pyvar(python::AbstractString, mod::AbstractString, var::AbstractString) = chomp(read(pythonenv(`$python -c "import $mod; print($mod.$(var))"`), String))
 
-pyconfigvar(python::AbstractString, var::AbstractString) = pyvar(python, "sysconfig", "get_config_var('$(var)')")
+function pyconfigvar(python::AbstractString, var::AbstractString)
+    try
+       pyvar(python, "sysconfig", "get_config_var('$(var)')")
+    catch e
+        emsg = sprint(showerror, e)
+        @warn "Encountered error on using `sysconfig`: $emsg. Falling back to `distutils.sysconfig`."
+        pyvar(python, "distutils.sysconfig", "get_config_var('$(var)')")
+    end
+end
 pyconfigvar(python, var, default) = let v = pyconfigvar(python, var)
     v == "None" ? default : v
 end


### PR DESCRIPTION
Required for Python 3.12 as distutils is removed.

@stevengj do you think you review and merge this when you get a chance? It's only a one-word change and is required for 3.12 compatibility in PyJulia.

cc @mkitti

Fixes https://github.com/JuliaPy/pyjulia/pull/538 (hopefully)