### PR TITLE
Add parsing for datetime.time

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -168,6 +168,7 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
 
     @test roundtripeq(Dates.Date(2012,3,4))
     @test roundtripeq(Dates.DateTime(2012,3,4, 7,8,9,11))
+    @test roundtripeq(Dates.Time(7,8,9,11))
     @test roundtripeq(Dates.Millisecond(typemax(Int32)))
     @test roundtripeq(Dates.Millisecond(typemin(Int32)))
     @test roundtripeq(Dates.Second, Dates.Second(typemax(Int32)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -167,8 +167,11 @@ const PyInt = pyversion < v"3" ? Int : Clonglong
     end
 
     @test roundtripeq(Dates.Date(2012,3,4))
+    @test_throws ArgumentError convert(Dates.Date, PyObject(42))
     @test roundtripeq(Dates.DateTime(2012,3,4, 7,8,9,11))
+    @test_throws ArgumentError convert(Dates.DateTime, PyObject(42))
     @test roundtripeq(Dates.Time(7,8,9,11))
+    @test_throws ArgumentError convert(Dates.Time, PyObject(42))
     @test roundtripeq(Dates.Millisecond(typemax(Int32)))
     @test roundtripeq(Dates.Millisecond(typemin(Int32)))
     @test roundtripeq(Dates.Second, Dates.Second(typemax(Int32)))


### PR DESCRIPTION
Using same patterns as elsewhere in this file (and avoiding timezones like in DateTime), add support for parsing times from the Python datetime package to Julia's Dates.Time struct. This came up as a need I had in a personal project and was a quick addition.