### PR TITLE
Remove unavailable Python 2.7 from GitHub actions

### DIFF
--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -41,16 +41,6 @@ jobs:
             architecture: x64
             python-version: '3.x'
             julia-version: '1.4'
-          # Test Python 2.7 only with a few combinations (TODO: drop 2.7).
-          # Note that it does not work in macOS:
-          - os: ubuntu-latest
-            architecture: x64
-            python-version: '2.7'
-            julia-version: '1'
-          - os: windows-2019
-            architecture: x64
-            python-version: '2.7'
-            julia-version: '1'
       fail-fast: false
     name: Test
       Julia ${{ matrix.julia-version }}


### PR DESCRIPTION
Python 2.7 is no longer available on any GitHub images: https://github.com/actions/python-versions/blob/main/versions-manifest.json, so this PR removes it from the GitHub actions tests.