### PR TITLE
Acquire GIL around every Python API call

### DIFF
--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -36,6 +36,7 @@ import Base.Iterators: filter
 
 include(joinpath(dirname(@__FILE__), "..", "deps","depsutils.jl"))
 include("startup.jl")
+include("gil.jl")
 
 """
 Python executable used by PyCall in the current process.
@@ -114,23 +115,25 @@ it is equivalent to a `PyNULL()` object.
 """
 ispynull(o::PyObject) = o ≛ PyPtr_NULL
 
-function pydecref_(o::Union{PyPtr,PyObject})
-    _finalized[] || ccall(@pysym(:Py_DecRef), Cvoid, (PyPtr,), o)
+function pydecref_(o::PyPtr)
+    if o !== PyPtr_NULL && !_finalized[]
+        @with_GIL ccall(@pysym(:Py_DecRef), Cvoid, (PyPtr,), o)
+    end
     return o
 end
 
 function pydecref(o::PyObject)
-    pydecref_(o)
+    pydecref_(getfield(o, :o))
     setfield!(o, :o, PyPtr_NULL)
     return o
 end
 
-function pyincref_(o::Union{PyPtr,PyObject})
-    ccall((@pysym :Py_IncRef), Cvoid, (PyPtr,), o)
+function pyincref_(o::PyPtr)
+    @with_GIL ccall((@pysym :Py_IncRef), Cvoid, (PyPtr,), o)
     return o
 end
 
-pyincref(o::PyObject) = pyincref_(o)
+pyincref(o::PyObject) = (pyincref_(getfield(o, :o)); o)
 
 # doing an incref *before* creating a PyObject may safer in the
 # case of borrowed references, to ensure that no exception or interrupt
@@ -165,13 +168,13 @@ function Base.copy!(dest::PyObject, src::PyObject)
 end
 
 pyisinstance(o::PyObject, t::PyObject) =
-  !ispynull(t) && ccall((@pysym :PyObject_IsInstance), Cint, (PyPtr,PyPtr), o, t) == 1
+  !ispynull(t) && @with_GIL(ccall((@pysym :PyObject_IsInstance), Cint, (PyPtr,PyPtr), o, t)) == 1
 
 pyisinstance(o::PyObject, t::Union{Ptr{Cvoid},PyPtr}) =
-  t != C_NULL && ccall((@pysym :PyObject_IsInstance), Cint, (PyPtr,PyPtr), o, t) == 1
+  t != C_NULL && @with_GIL(ccall((@pysym :PyObject_IsInstance), Cint, (PyPtr,PyPtr), o, t)) == 1
 
 pyquery(q::Ptr{Cvoid}, o::PyObject) =
-  ccall(q, Cint, (PyPtr,), o) == 1
+  @with_GIL(ccall(q, Cint, (PyPtr,), o)) == 1
 
 # conversion to pass PyObject as ccall arguments:
 unsafe_convert(::Type{PyPtr}, po::PyObject) = PyPtr(po)
@@ -240,10 +243,10 @@ function pystring(o::PyObject)
     if ispynull(o)
         return "NULL"
     else
-        s = ccall((@pysym :PyObject_Repr), PyPtr, (PyPtr,), o)
+        s = @with_GIL ccall((@pysym :PyObject_Repr), PyPtr, (PyPtr,), o)
         if (s == C_NULL)
             pyerr_clear()
-            s = ccall((@pysym :PyObject_Str), PyPtr, (PyPtr,), o)
+            s = @with_GIL ccall((@pysym :PyObject_Str), PyPtr, (PyPtr,), o)
             if (s == C_NULL)
                 pyerr_clear()
                 return string(PyPtr(o))
@@ -281,7 +284,7 @@ function hash(o::PyObject, salt::UInt)
         # since on 64-bit Windows the Python 2.x hash is only 32 bits
         hash(unsafe_pyjlwrap_to_objref(o), salt)
     else
-        h = ccall((@pysym :PyObject_Hash), Py_hash_t, (PyPtr,), o)
+        h = @with_GIL ccall((@pysym :PyObject_Hash), Py_hash_t, (PyPtr,), o)
         if h == -1 # error
             pyerr_clear()
             return hash(PyPtr(o), salt)
@@ -297,7 +300,7 @@ end
 
 function _getproperty(o::PyObject, s::Union{AbstractString,Symbol})
     ispynull(o) && throw(ArgumentError("ref of NULL PyObject"))
-    p = ccall((@pysym :PyObject_GetAttrString), PyPtr, (PyPtr, Cstring), o, s)
+    p = @with_GIL ccall((@pysym :PyObject_GetAttrString), PyPtr, (PyPtr, Cstring), o, s)
     if p == C_NULL && pyerr_occurred()
         e = PyError("PyObject_GetAttrString")
         if PyPtr(e.T) != @pyglobalobjptr(:PyExc_AttributeError)
@@ -334,7 +337,7 @@ setproperty!(o::PyObject, s::AbstractString, v) = _setproperty!(o,s,v)
 
 function _setproperty!(o::PyObject, s::Union{Symbol,AbstractString}, v)
     ispynull(o) && throw(ArgumentError("assign of NULL PyObject"))
-    p = ccall((@pysym :PyObject_SetAttrString), Cint, (PyPtr, Cstring, PyPtr), o, s, PyObject(v))
+    p = @with_GIL ccall((@pysym :PyObject_SetAttrString), Cint, (PyPtr, Cstring, PyPtr), o, s, PyObject(v))
     if p == -1 && pyerr_occurred()
         e = PyError("PyObject_SetAttrString")
         if PyPtr(e.T) != @pyglobalobjptr(:PyExc_AttributeError)
@@ -370,8 +373,8 @@ function pyhasproperty(o::PyObject, s::Union{Symbol,AbstractString})
     if ispynull(o)
         throw(ArgumentError("hasproperty of NULL PyObject"))
     end
-    return 1 == ccall((@pysym :PyObject_HasAttrString), Cint,
-                      (PyPtr, Cstring), o, s)
+    return 1 == @with_GIL(ccall((@pysym :PyObject_HasAttrString), Cint,
+                                (PyPtr, Cstring), o, s))
 end
 hasproperty(o::PyObject, s::Symbol) = pyhasproperty(o, s)
 hasproperty(o::PyObject, s::AbstractString) = pyhasproperty(o, s)
@@ -480,7 +483,7 @@ end
 function _pyimport(name::AbstractString)
     cookie = ActivatePyActCtx()
     try
-        return PyObject(ccall((@pysym :PyImport_ImportModule), PyPtr, (Cstring,), name))
+        return @with_GIL PyObject(ccall((@pysym :PyImport_ImportModule), PyPtr, (Cstring,), name))
     finally
         DeactivatePyActCtx(cookie)
     end
@@ -685,7 +688,7 @@ string otherwise.
 """
 function anaconda_conda()
     # Anaconda Python seems to always include "Anaconda" in the version string.
-    if conda || !occursin("conda", unsafe_string(ccall(@pysym(:Py_GetVersion), Ptr{UInt8}, ())))
+    if conda || !occursin("conda", unsafe_string(@with_GIL ccall(@pysym(:Py_GetVersion), Ptr{UInt8}, ())))
         return ""
     end
     aconda = joinpath(dirname(pyprogramname), "conda")
@@ -770,7 +773,7 @@ include("pyfncall.jl")
 # for now we can define "get".
 
 function get(o::PyObject, returntype::TypeTuple, k, default)
-    r = ccall((@pysym :PyObject_GetItem), PyPtr, (PyPtr,PyPtr), o,PyObject(k))
+    r = @with_GIL ccall((@pysym :PyObject_GetItem), PyPtr, (PyPtr,PyPtr), o,PyObject(k))
     if r == C_NULL
         pyerr_clear()
         default
@@ -781,13 +784,13 @@ end
 
 get(o::PyObject, returntype::TypeTuple, k) =
     convert(returntype, PyObject(@pycheckn ccall((@pysym :PyObject_GetItem),
-                                 PyPtr, (PyPtr,PyPtr), o, PyObject(k))))
+                                                PyPtr, (PyPtr,PyPtr), o, PyObject(k))))
 
 get(o::PyObject, k, default) = get(o, PyAny, k, default)
 get(o::PyObject, k) = get(o, PyAny, k)
 
 function delete!(o::PyObject, k)
-    e = ccall((@pysym :PyObject_DelItem), Cint, (PyPtr, PyPtr), o, PyObject(k))
+    e = @with_GIL ccall((@pysym :PyObject_DelItem), Cint, (PyPtr, PyPtr), o, PyObject(k))
     if e == -1
         pyerr_clear() # delete! ignores errors in Julia
     end
@@ -959,7 +962,7 @@ function get_real_method(obj, name)
         return nothing
     end
 
-    ccall((@pysym :PyCallable_Check), Cint, (PyPtr,), m) == 1 && return m
+    @with_GIL(ccall((@pysym :PyCallable_Check), Cint, (PyPtr,), m)) == 1 && return m
 
     return nothing
 end

--- a/src/PyCall.jl
+++ b/src/PyCall.jl
@@ -77,7 +77,7 @@ mutable struct PyObject
     o::PyPtr # the actual PyObject*
     function PyObject(o::PyPtr)
         po = new(o)
-        finalizer(pydecref, po)
+        finalizer(_defer_Py_DecRef, po)
         return po
     end
 end
@@ -116,9 +116,7 @@ it is equivalent to a `PyNULL()` object.
 ispynull(o::PyObject) = o ≛ PyPtr_NULL
 
 function pydecref_(o::PyPtr)
-    if o !== PyPtr_NULL && !_finalized[]
-        @with_GIL ccall(@pysym(:Py_DecRef), Cvoid, (PyPtr,), o)
-    end
+    @with_GIL ccall(@pysym(:Py_DecRef), Cvoid, (PyPtr,), o)
     return o
 end
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -12,7 +12,7 @@
                                                     PyPtr, (Int,), i))
 else
     PyObject(i::Unsigned) = PyObject(@pycheckn ccall(@pysym(:PyLong_FromUnsignedLongLong),
-                                                    PyPtr, (Culonglong,), i))
+                                                     PyPtr, (Culonglong,), i))
     PyObject(i::Integer) = PyObject(@pycheckn ccall(@pysym(:PyLong_FromLongLong),
                                                     PyPtr, (Clonglong,), i))
 end
@@ -80,8 +80,8 @@ function PyObject(s::AbstractString)
     sb = String(s)
     if pyunicode_literals || !isascii(sb)
         PyObject(@pycheckn ccall(@pysym(PyUnicode_DecodeUTF8),
-                                 PyPtr, (Ptr{UInt8}, Int, Ptr{UInt8}),
-                                 sb, sizeof(sb), C_NULL))
+                                PyPtr, (Ptr{UInt8}, Int, Ptr{UInt8}),
+                                sb, sizeof(sb), C_NULL))
     else
         pybytes(sb)
     end
@@ -92,7 +92,7 @@ const _ps_len = Int[0]
 function convert(::Type{T}, po::PyObject) where T<:AbstractString
     if pyisinstance(po, @pyglobalobj :PyUnicode_Type)
         convert(T, PyObject(@pycheckn ccall(@pysym(PyUnicode_AsUTF8String),
-                                             PyPtr, (PyPtr,), po)))
+                                          PyPtr, (PyPtr,), po)))
     else
         @pycheckz ccall(@pysym(PyString_AsStringAndSize),
                         Cint, (PyPtr, Ptr{Ptr{UInt8}}, Ptr{Int}),
@@ -223,8 +223,8 @@ function convert(tt::Type{T}, o::PyObject) where T<:Tuple
     end
     ntuple((i ->
             convert(tuptype(T, isva, i),
-                    PyObject(ccall((@pysym :PySequence_GetItem), PyPtr,
-                                   (PyPtr, Int), o, i-1)))),
+                    PyObject(@with_GIL ccall((@pysym :PySequence_GetItem), PyPtr,
+                                             (PyPtr, Int), o, i-1)))),
            len)
 end
 
@@ -346,7 +346,7 @@ function py2array(T, A::Array{TA,N}, o::PyObject,
             error("dimension mismatch in py2array")
         end
         s = stride(A, dim)
-        for j = 0:len-1
+        @with_GIL for j = 0:len-1
             A[i+j*s] = convert(T, PyObject(ccall((@pysym :PySequence_GetItem),
                                                  PyPtr, (PyPtr, Int), o, j)))
         end
@@ -357,7 +357,7 @@ function py2array(T, A::Array{TA,N}, o::PyObject,
             error("dimension mismatch in py2array")
         end
         s = stride(A, dim)
-        for j = 0:len-1
+        @with_GIL for j = 0:len-1
             py2array(T, A, PyObject(ccall((@pysym :PySequence_GetItem),
                                        PyPtr, (PyPtr, Int), o, j)),
                      dim+1, i+j*s)
@@ -376,13 +376,13 @@ function pyarray_dims(o::PyObject, forcelist=true)
     if len == 0
         return (0,)
     end
-    dims0 = pyarray_dims(PyObject(ccall((@pysym :PySequence_GetItem),
-                                        PyPtr, (PyPtr, Int), o, 0)),
+    dims0 = pyarray_dims(PyObject(@with_GIL(ccall((@pysym :PySequence_GetItem),
+                                                  PyPtr, (PyPtr, Int), o, 0))),
                          false)
     if isempty(dims0) # not a nested sequence
         return (len,)
     end
-    for j = 1:len-1
+    @with_GIL for j = 1:len-1
         dims = pyarray_dims(PyObject(ccall((@pysym :PySequence_GetItem),
                                            PyPtr, (PyPtr, Int), o, j)),
                             false)
@@ -408,7 +408,7 @@ function py2array(T, o::PyObject)
 end
 
 function py2vector(T, o::PyObject)
-    len = ccall((@pysym :PySequence_Size), Int, (PyPtr,), o)
+    len = @with_GIL ccall((@pysym :PySequence_Size), Int, (PyPtr,), o)
     if len < 0 || # not a sequence
        len+1 < 0  # object pretending to be a sequence of infinite length
         pyerr_clear()
@@ -435,7 +435,7 @@ include("numpy.jl")
 function is_mapping_object(o::PyObject)
     pyisinstance(o, @pyglobalobj :PyDict_Type) ||
     (pyquery((@pyglobal :PyMapping_Check), o) &&
-      ccall((@pysym :PyObject_HasAttrString), Cint, (PyPtr,Ptr{UInt8}), o, "items") == 1)
+      @with_GIL(ccall((@pysym :PyObject_HasAttrString), Cint, (PyPtr,Ptr{UInt8}), o, "items")) == 1)
 end
 
 """
@@ -472,13 +472,13 @@ convert(::Type{PyDict}, o::PyObject) = PyDict(o)
 convert(::Type{PyDict{K,V}}, o::PyObject) where {K,V} = PyDict{K,V}(o)
 unsafe_convert(::Type{PyPtr}, d::PyDict) = PyPtr(d.o)
 
-haskey(d::PyDict{K,V,true}, key) where {K,V} = 1 == ccall(@pysym(:PyDict_Contains), Cint, (PyPtr, PyPtr), d, PyObject(key))
+haskey(d::PyDict{K,V,true}, key) where {K,V} = 1 == @with_GIL(ccall(@pysym(:PyDict_Contains), Cint, (PyPtr, PyPtr), d, PyObject(key)))
 keys(::Type{T}, d::PyDict{K,V,true}) where {T,K,V} = convert(Vector{T}, PyObject(@pycheckn ccall((@pysym :PyDict_Keys), PyPtr, (PyPtr,), d)))
 values(::Type{T}, d::PyDict{K,V,true}) where {T,K,V} = convert(Vector{T}, PyObject(@pycheckn ccall((@pysym :PyDict_Values), PyPtr, (PyPtr,), d)))
 
 keys(::Type{T}, d::PyDict{K,V,false}) where {T,K,V} = convert(Vector{T}, pycall(d.o["keys"], PyObject))
 values(::Type{T}, d::PyDict{K,V,false}) where {T,K,V} = convert(Vector{T}, pycall(d.o["values"], PyObject))
-haskey(d::PyDict{K,V,false}, key) where {K,V} = 1 == ccall(@pysym(:PyMapping_HasKey), Cint, (PyPtr, PyPtr), d, PyObject(key))
+haskey(d::PyDict{K,V,false}, key) where {K,V} = 1 == @with_GIL(ccall(@pysym(:PyMapping_HasKey), Cint, (PyPtr, PyPtr), d, PyObject(key)))
 
 similar(d::PyDict{K,V}) where {K,V} = Dict{pyany_toany(K),pyany_toany(V)}()
 eltype(::Type{PyDict{K,V}}) where {K,V} = Pair{pyany_toany(K),pyany_toany(V)}
@@ -515,12 +515,12 @@ function pop!(d::PyDict, k, default)
 end
 
 function delete!(d::PyDict{K,V,true}, k) where {K,V}
-    e = ccall(@pysym(:PyDict_DelItem), Cint, (PyPtr, PyPtr), d, PyObject(k))
+    e = @with_GIL ccall(@pysym(:PyDict_DelItem), Cint, (PyPtr, PyPtr), d, PyObject(k))
     e == -1 && pyerr_clear() # delete! ignores errors in Julia
     return d
 end
 function delete!(d::PyDict{K,V,false}, k) where {K,V}
-    e = ccall(@pysym(:PyObject_DelItem), Cint, (PyPtr, PyPtr), d, PyObject(k))
+    e = @with_GIL ccall(@pysym(:PyObject_DelItem), Cint, (PyPtr, PyPtr), d, PyObject(k))
     e == -1 && pyerr_clear() # delete! ignores errors in Julia
     return d
 end
@@ -553,9 +553,9 @@ end
 
 function Base.iterate(d::PyDict{K,V,true}, itr=PyDict_Iterator(Ref{PyPtr}(), Ref{PyPtr}(), Ref(0), 0, length(d))) where {K,V}
     itr.i >= itr.len && return nothing
-    if 0 == ccall((@pysym :PyDict_Next), Cint,
-                    (PyPtr, Ref{Int}, Ref{PyPtr}, Ref{PyPtr}),
-                    d, itr.pa, itr.ka, itr.va)
+    if 0 == @with_GIL(ccall((@pysym :PyDict_Next), Cint,
+                            (PyPtr, Ref{Int}, Ref{PyPtr}, Ref{PyPtr}),
+                            d, itr.pa, itr.ka, itr.va))
         error("unexpected end of PyDict_Next")
     end
     ko = pyincref(itr.ka[]) # PyDict_Next returns
@@ -751,7 +751,7 @@ function pysequence_query(o::PyObject)
     # problems
     if pyisinstance(o, @pyglobalobj :PyTuple_Type)
         len = length(o)
-        return typetuple(pytype_query(PyObject(ccall((@pysym :PySequence_GetItem), PyPtr, (PyPtr,Int), o,i-1)), PyAny) for i = 1:len)
+        return typetuple(pytype_query(PyObject(@with_GIL(ccall((@pysym :PySequence_GetItem), PyPtr, (PyPtr,Int), o,i-1))), PyAny) for i = 1:len)
     elseif pyisinstance(o, pyxrange[])
         return AbstractRange
     elseif ispybytearray(o)

--- a/src/exception.jl
+++ b/src/exception.jl
@@ -51,11 +51,12 @@ end
 
 # like pyerror(msg) but type-stable: always returns PyError
 function PyError(msg::AbstractString)
-    ptype, pvalue, ptraceback = Ref{PyPtr}(), Ref{PyPtr}(), Ref{PyPtr}()
-    # equivalent of passing C pointers &exc[1], &exc[2], &exc[3]:
-    ccall((@pysym :PyErr_Fetch), Cvoid, (Ref{PyPtr},Ref{PyPtr},Ref{PyPtr}), ptype, pvalue, ptraceback)
-    ccall((@pysym :PyErr_NormalizeException), Cvoid, (Ref{PyPtr},Ref{PyPtr},Ref{PyPtr}), ptype, pvalue, ptraceback)
-    return PyError(msg, PyObject(ptype[]), PyObject(pvalue[]), PyObject(ptraceback[]))
+    return @with_GIL begin
+        ptype, pvalue, ptraceback = Ref{PyPtr}(), Ref{PyPtr}(), Ref{PyPtr}()
+        ccall((@pysym :PyErr_Fetch), Cvoid, (Ref{PyPtr},Ref{PyPtr},Ref{PyPtr}), ptype, pvalue, ptraceback)
+        ccall((@pysym :PyErr_NormalizeException), Cvoid, (Ref{PyPtr},Ref{PyPtr},Ref{PyPtr}), ptype, pvalue, ptraceback)
+        PyError(msg, PyObject(ptype[]), PyObject(pvalue[]), PyObject(ptraceback[]))
+    end
 end
 
 # replace the message from another error
@@ -66,10 +67,10 @@ PyError(msg::AbstractString, e::PyError) =
 # Conversion of Python exceptions into Julia exceptions
 
 # whether a Python exception has occurred
-pyerr_occurred() = ccall((@pysym :PyErr_Occurred), PyPtr, ()) != C_NULL
+pyerr_occurred() = @with_GIL ccall((@pysym :PyErr_Occurred), PyPtr, ()) != C_NULL
 
 # call to discard Python exceptions
-pyerr_clear() = ccall((@pysym :PyErr_Clear), Cvoid, ())
+pyerr_clear() = @with_GIL ccall((@pysym :PyErr_Clear), Cvoid, ())
 
 function pyerr_check(msg::AbstractString, val::Any)
     pyerr_occurred() && throw(pyerror(msg))
@@ -99,13 +100,13 @@ end
 
 # Macros for common pyerr_check("Foo", ccall((@pysym :Foo), ...)) pattern.
 macro pycheck(ex)
-    :(pyerr_check($(string(callsym(ex))), $(esc(ex))))
+    :(pyerr_check($(string(callsym(ex))), @with_GIL($(esc(ex)))))
 end
 
 # Macros to check that ccall((@pysym :Foo), ...) returns value != bad
 macro pycheckv(ex, bad)
     quote
-        val = $(esc(ex))
+        val = @with_GIL($(esc(ex)))
         if val == $(esc(bad))
             _handle_error($(string(callsym(ex))))
         end
@@ -223,14 +224,14 @@ function pyraise(e, bt = nothing)
     eT = typeof(e)
     pyeT = haskey(pyexc, eT) ? pyexc[eT] : pyexc[Exception]
     err = PyJlError(e, bt)
-    ccall((@pysym :PyErr_SetObject), Cvoid, (PyPtr, PyPtr),
-          pyeT, PyObject(err))
+    @with_GIL ccall((@pysym :PyErr_SetObject), Cvoid, (PyPtr, PyPtr),
+                    pyeT, PyObject(err))
 end
 
 # Second argument allows for backtraces passed to `pyraise` to be ignored.
 function pyraise(e::PyError, ::Vector = [])
-    ccall((@pysym :PyErr_Restore), Cvoid, (PyPtr, PyPtr, PyPtr),
-          e.T, e.val, e.traceback)
+    @with_GIL ccall((@pysym :PyErr_Restore), Cvoid, (PyPtr, PyPtr, PyPtr),
+                    e.T, e.val, e.traceback)
     # refs were stolen
     setfield!(e.T, :o, PyPtr_NULL)
     setfield!(e.val, :o, PyPtr_NULL)

--- a/src/gc.jl
+++ b/src/gc.jl
@@ -11,6 +11,8 @@
 #      when po is deallocated, and this callback function removes
 #      jo from pycall_gc so that Julia can garbage-collect it.
 
+using Base.Threads: atomic_add!, atomic_sub!, Atomic, SpinLock
+
 const pycall_gc = Dict{PyPtr,Any}()
 
 function weakref_callback(callback::PyPtr, wo::PyPtr)
@@ -42,4 +44,75 @@ function pyembed(po::PyObject, jo::Any)
                          po, weakref_callback_obj)
     pycall_gc[wo] = jo
     return po
+end
+
+# Deferred `finalizer` / destructor queue(s):
+#
+#   * In a `finalizer` context, it is unsafe to take the GIL since it
+#     can cause deadlocks such as:
+#
+#       1. Task A holds the GIL and waits for Task B to finish something
+#       2. Task B enters GC and tries runs finalizers
+#       3. Task B cannot acquire the GIL and Task A is stuck waiting on B
+#
+#   * To work around this, we defer any GIL-requiring operations to run
+#     at the end of next `@with_GIL` block.
+
+const _deferred_count = Atomic{Int}(0)
+const _deferred_Py_DecRef = Vector{PyPtr}()
+const _deferred_PyBuffer_Release = Vector{PyBuffer}()
+
+# Since it is illegal for finalizers to `yield()` to the Julia scheduler, this
+# lock MUST be a `SpinLock` or similar. Most other locks in `Base` implicitly
+# yield.
+const _deferred_queue_lock = SpinLock()
+
+# Defers a `Py_DecRef(o)` call to be performed later, when the GIL is available
+function _defer_Py_DecRef(o::PyObject)
+    lock(_deferred_queue_lock)
+    try
+        push!(_deferred_Py_DecRef, getfield(o, :o))
+        atomic_add!(_deferred_count, 1)
+    finally
+        unlock(_deferred_queue_lock)
+    end
+    return
+end
+
+# Defers a `PyBuffer_Release(o)` call to be performed later, when the GIL is available
+function _defer_PyBuffer_Release(o::PyBuffer)
+    lock(_deferred_queue_lock)
+    try
+        push!(_deferred_PyBuffer_Release, o)
+        atomic_add!(_deferred_count, 1)
+    finally
+        unlock(_deferred_queue_lock)
+    end
+    return
+end
+
+# Called at the end of every `@with_GIL` block, this performs any deferred destruction
+# operations from finalizers that could not be done immediately due to not holding the GIL
+@noinline function _drain_release_queues()
+    lock(_deferred_queue_lock)
+
+    atomic_sub!(_deferred_count, length(_deferred_Py_DecRef))
+    atomic_sub!(_deferred_count, length(_deferred_PyBuffer_Release))
+
+    Py_DecRefs = copy(_deferred_Py_DecRef)
+    PyBuffer_Releases = copy(_deferred_PyBuffer_Release)
+
+    empty!(_deferred_Py_DecRef)
+    empty!(_deferred_PyBuffer_Release)
+
+    unlock(_deferred_queue_lock)
+
+    for o in Py_DecRefs
+        ccall(@pysym(:Py_DecRef), Cvoid, (PyPtr,), o)
+    end
+    for o in PyBuffer_Releases
+        ccall(@pysym(:PyBuffer_Release), Cvoid, (Ref{PyBuffer},), o)
+    end
+
+    return nothing
 end

--- a/src/gil.jl
+++ b/src/gil.jl
@@ -2,6 +2,10 @@
 
 const _GIL_owner = Threads.Atomic{UInt}(0)
 
+# Forward declare deferred destructors
+function _defer_Py_DecRef end
+function _defer_PyBuffer_Release end
+
 # Acquires the GIL.
 # This lock can be re-acquired if already held by the OS thread (it is re-entrant).
 function GIL_lock()
@@ -52,7 +56,11 @@ macro with_GIL(expr)
         else
             local _state = GIL_lock()
             try
-                $(esc(expr))
+                local val = $(esc(expr))
+                if _deferred_count[] != 0
+                    _drain_release_queues()
+                end
+                val
             finally
                 GIL_unlock(_state)
             end

--- a/src/gil.jl
+++ b/src/gil.jl
@@ -1,0 +1,61 @@
+# GIL management functionality
+
+const _GIL_owner = Threads.Atomic{UInt}(0)
+
+# Acquires the GIL.
+# This lock can be re-acquired if already held by the OS thread (it is re-entrant).
+function GIL_lock()
+    state = ccall((@pysym :PyGILState_Ensure), Cint, ())
+    _GIL_owner[] = objectid(current_task())
+    return state
+end
+
+# Releases the GIL.
+# Argument is the state from a corresponding `GIL_lock()` call.
+function GIL_unlock(state::Cint)
+    _GIL_owner[] = UInt(0)
+    ccall((@pysym :PyGILState_Release), Cvoid, (Cint,), state)
+end
+
+# Quickly check whether this task holds the GIL.
+#
+# If true, the current task is guaranteed to be holding the GIL.
+# May return false even if the GIL is currently held.
+function GIL_held()
+    return _GIL_owner[] == objectid(current_task())
+end
+
+"""
+    @with_GIL expr
+
+Execute `expr` while holding the Python GIL. Safe to nest (re-entrant).
+
+!!! warning "Illegal to yield to the Julia scheduler"
+
+    GIL-locked code MUST NOT access any Julia-side locks or I/O or call
+    `yield()`. This is required to avoid task-migration, which would
+    leave the GIL held on an "old" OS thread and unable to be released.
+
+    This condition may be relaxed in the future if
+    [https://github.com/JuliaLang/julia/issues/52108](https://github.com/JuliaLang/julia/issues/52108)
+    is resolved.
+"""
+macro with_GIL(expr)
+    # TODO:
+    #   If OS thread pinning is eventually supported in Julia
+    #   (c.f. https://github.com/JuliaLang/julia/issues/52108),
+    #   replace this with a yield-safe version
+    quote
+        if GIL_held()
+            # Fast path: GIL already held on this OS thread, just run directly
+            $(esc(expr))
+        else
+            local _state = GIL_lock()
+            try
+                $(esc(expr))
+            finally
+                GIL_unlock(_state)
+            end
+        end
+    end
+end

--- a/src/gil.jl
+++ b/src/gil.jl
@@ -2,6 +2,20 @@
 
 const _GIL_owner = Threads.Atomic{UInt}(0)
 
+# It is not legal for Julia code to spin directly on "foreign" locks such as
+# the GIL, since this can mean never making progress toward:
+#
+#   * GC safepoints, which causes deadlocks when other threads initiate a GC
+#     and wait forever for all threads to "stop".
+#
+#   * yield() points, which can starve the scheduler and also lead to deadlocks
+#     since Tasks waiting for the GIL can block other Tasks ready to make
+#     progress from being scheduled.
+#
+# Instead we are required to hold a Julia-side lock that is GC-aware + scheduler-
+# aware whenever we hold the foreign GIL, preventing these deadlocks.
+const _jl_gil = ReentrantLock()
+
 # Forward declare deferred destructors
 function _defer_Py_DecRef end
 function _defer_PyBuffer_Release end
@@ -9,6 +23,7 @@ function _defer_PyBuffer_Release end
 # Acquires the GIL.
 # This lock can be re-acquired if already held by the OS thread (it is re-entrant).
 function GIL_lock()
+    lock(_jl_gil)
     state = ccall((@pysym :PyGILState_Ensure), Cint, ())
     _GIL_owner[] = objectid(current_task())
     return state
@@ -19,6 +34,7 @@ end
 function GIL_unlock(state::Cint)
     _GIL_owner[] = UInt(0)
     ccall((@pysym :PyGILState_Release), Cvoid, (Cint,), state)
+    unlock(_jl_gil)
 end
 
 # Quickly check whether this task holds the GIL.

--- a/src/pybuffer.jl
+++ b/src/pybuffer.jl
@@ -32,7 +32,7 @@ mutable struct PyBuffer
         b = new(Py_buffer(C_NULL, PyPtr_NULL, 0, 0,
                           0, 0, C_NULL, C_NULL, C_NULL, C_NULL,
                           C_NULL, C_NULL, C_NULL))
-        finalizer(pydecref, b)
+        finalizer(_defer_PyBuffer_Release, b)
         return b
     end
 end
@@ -45,11 +45,7 @@ It is an error to call this function on a PyBuffer that was not obtained via
 the python c-api function `PyObject_GetBuffer()`, unless o.obj is a PyPtr(C_NULL)
 """
 function pydecref(o::PyBuffer)
-    # note that PyBuffer_Release sets o.obj to NULL, and
-    # is a no-op if o.obj is already NULL
-    if !_finalized[]
-        @with_GIL ccall(@pysym(:PyBuffer_Release), Cvoid, (Ref{PyBuffer},), o)
-    end
+    @with_GIL ccall(@pysym(:PyBuffer_Release), Cvoid, (Ref{PyBuffer},), o)
     o
 end
 

--- a/src/pybuffer.jl
+++ b/src/pybuffer.jl
@@ -47,7 +47,9 @@ the python c-api function `PyObject_GetBuffer()`, unless o.obj is a PyPtr(C_NULL
 function pydecref(o::PyBuffer)
     # note that PyBuffer_Release sets o.obj to NULL, and
     # is a no-op if o.obj is already NULL
-    _finalized[] || ccall(@pysym(:PyBuffer_Release), Cvoid, (Ref{PyBuffer},), o)
+    if !_finalized[]
+        @with_GIL ccall(@pysym(:PyBuffer_Release), Cvoid, (Ref{PyBuffer},), o)
+    end
     o
 end
 
@@ -96,8 +98,8 @@ end
 Base.strides(b::PyBuffer) = ((stride(b,i) for i in 1:b.buf.ndim)...,)
 
 iscontiguous(b::PyBuffer) =
-    1 == ccall((@pysym :PyBuffer_IsContiguous), Cint,
-               (Ref{PyBuffer}, Cchar), b, 'A')
+    1 == @with_GIL(ccall((@pysym :PyBuffer_IsContiguous), Cint,
+                         (Ref{PyBuffer}, Cchar), b, 'A'))
 
 #############################################################################
 # pybuffer constant values from Include/object.h
@@ -131,8 +133,8 @@ function isbuftype!(o::Union{PyObject,PyPtr}, b::PyBuffer)
     # PyObject_CheckBuffer is defined in a header file here: https://github.com/python/cpython/blob/ef5ce884a41c8553a7eff66ebace908c1dcc1f89/Include/abstract.h#L510
     # so we can't access it easily. It basically just checks if PyObject_GetBuffer exists
     # So we'll just try call PyObject_GetBuffer and check for success/failure
-    ret = ccall((@pysym :PyObject_GetBuffer), Cint,
-                     (PyPtr, Any, Cint), o, b, PyBUF_ND_STRIDED)
+    ret = @with_GIL ccall((@pysym :PyObject_GetBuffer), Cint,
+                          (PyPtr, Any, Cint), o, b, PyBUF_ND_STRIDED)
     if ret != 0
         pyerr_clear()
     end

--- a/src/pyfncall.jl
+++ b/src/pyfncall.jl
@@ -41,8 +41,8 @@ function __pycall!(ret::PyObject, pyargsptr::PyPtr, o::Union{PyObject,PyPtr},
   kw::Union{Ptr{Cvoid}, PyObject})
     disable_sigint() do
         retptr = @pycheckn ccall((@pysym :PyObject_Call), PyPtr, (PyPtr,PyPtr,PyPtr), o,
-                        pyargsptr, kw)
-        pydecref_(ret)
+                                 pyargsptr, kw)
+        pydecref_(getfield(ret, :o))
         setfield!(ret, :o, retptr)
     end
     return ret #::PyObject

--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -109,7 +109,7 @@ end
 
 #########################################################################
 
-const _finalized = Ref(false)
+const _finalized = Threads.Atomic{Bool}(false)
 # This flag is set via `Py_AtExit` to avoid calling `pydecref_` after
 # Python is finalized.
 
@@ -117,10 +117,12 @@ function _set_finalized()
     # This function MUST NOT invoke any Python APIs.
     # https://docs.python.org/3/c-api/sys.html#c.Py_AtExit
     _finalized[] = true
+    _GIL_owner[] = UInt(0)
     return nothing
 end
 
 function Py_Finalize()
+    GIL_lock()
     pygui_stop_all()
     ccall(@pysym(:Py_Finalize), Cvoid, ())
 end
@@ -129,6 +131,7 @@ function __init__()
     # Clear out global states.  This is required only for PyCall
     # AOT-compiled into system image.
     _finalized[] = false
+    _GIL_owner[] = UInt(0)
     empty!(_namespaces)
     empty!(eventloops)
     global npy_initialized = false
@@ -264,6 +267,11 @@ function __init__()
             sys."stderr"."flush"()
         end
     end
+
+    # Release the GIL so that any Julia thread can acquire it.
+    # After this point, all Python C API calls must go through
+    # @with_GIL or @pycheck, @pycheckn, etc.
+    ccall((@pysym :PyEval_SaveThread), Ptr{Cvoid}, ())
 
     # Configure finalization steps.
     #

--- a/src/pyinit.jl
+++ b/src/pyinit.jl
@@ -109,14 +109,9 @@ end
 
 #########################################################################
 
-const _finalized = Threads.Atomic{Bool}(false)
-# This flag is set via `Py_AtExit` to avoid calling `pydecref_` after
-# Python is finalized.
-
 function _set_finalized()
     # This function MUST NOT invoke any Python APIs.
     # https://docs.python.org/3/c-api/sys.html#c.Py_AtExit
-    _finalized[] = true
     _GIL_owner[] = UInt(0)
     return nothing
 end
@@ -130,7 +125,6 @@ end
 function __init__()
     # Clear out global states.  This is required only for PyCall
     # AOT-compiled into system image.
-    _finalized[] = false
     _GIL_owner[] = UInt(0)
     empty!(_namespaces)
     empty!(eventloops)

--- a/src/pyiterator.jl
+++ b/src/pyiterator.jl
@@ -149,12 +149,12 @@ end
 # Broadcasting: if the object is iterable, return collect(o), and otherwise
 #               return o.
 function Base.Broadcast.broadcastable(o::PyObject)
-    iter = ccall((@pysym :PyObject_GetIter), PyPtr, (PyPtr,), o)
+    iter = @with_GIL ccall((@pysym :PyObject_GetIter), PyPtr, (PyPtr,), o)
     if iter == C_NULL
         pyerr_clear()
         return Ref(o)
     else
-        ccall(@pysym(:Py_DecRef), Cvoid, (PyPtr,), iter)
+        @with_GIL ccall(@pysym(:Py_DecRef), Cvoid, (PyPtr,), iter)
         return collect(o)
     end
 end

--- a/src/pytype.jl
+++ b/src/pytype.jl
@@ -313,7 +313,7 @@ function PyTypeObject!(init::Function, t::PyTypeObject, name::AbstractString, ba
         t.tp_new = @pyglobal :PyType_GenericNew
     end
     @pycheckz ccall((@pysym :PyType_Ready), Cint, (Ref{PyTypeObject},), t)
-    ccall((@pysym :Py_IncRef), Cvoid, (Any,), t)
+    @with_GIL ccall((@pysym :Py_IncRef), Cvoid, (Any,), t)
     return t
 end
 
@@ -416,7 +416,7 @@ function pyjlwrap_type!(init::Function, to::PyTypeObject, name::AbstractString)
         # We want tp_base to be a pointer to the C-like PyTypeObject struct.
         # This is equivalent to the jl_value_t* in Julia (see JuliaLang/julia#31473).
         t.tp_base = pointer_from_objref(jlWrapType)
-        ccall((@pysym :Py_IncRef), Cvoid, (Ref{PyTypeObject},), jlWrapType)
+        @with_GIL ccall((@pysym :Py_IncRef), Cvoid, (Ref{PyTypeObject},), jlWrapType)
         init(t)
     end
 end
@@ -451,7 +451,7 @@ function pyjlwrap_new(x::Any)
     pyjlwrap_new(jlWrapType, x)
 end
 
-is_pyjlwrap(o::PyObject) = jlWrapType.tp_new != C_NULL && ccall((@pysym :PyObject_IsInstance), Cint, (PyPtr, Ref{PyTypeObject}), o, jlWrapType) == 1
+is_pyjlwrap(o::PyObject) = jlWrapType.tp_new != C_NULL && @with_GIL(ccall((@pysym :PyObject_IsInstance), Cint, (PyPtr, Ref{PyTypeObject}), o, jlWrapType)) == 1
 
 ################################################################
 # Fallback conversion: if we don't have a better conversion function,

--- a/test/gil.jl
+++ b/test/gil.jl
@@ -1,15 +1,42 @@
 using Test, PyCall
 using Base.Threads
 
-@testset "GIL / multi-threading" begin
-    o = PyObject(randn(3,3))
-    t = Threads.@spawn begin
-        # Test that accessing `PyObject` across threads / tasks
-        # does not immediately segfault (GIL is acquired correctly).
-        iob = IOBuffer()
-        println(iob, propertynames(o))
-        str = String(take!(iob))
-        return length(str)
+@testset "GIL" begin
+
+    @testset "basic multi-threading" begin
+        o = PyObject(randn(3,3))
+        t = Threads.@spawn begin
+            # Test that accessing `PyObject` across threads / tasks
+            # does not immediately segfault (GIL is acquired correctly).
+            iob = IOBuffer()
+            println(iob, propertynames(o))
+            str = String(take!(iob))
+            return length(str)
+        end
+        @test fetch(t) != 0
     end
-    @test fetch(t) != 0
+
+    @testset "finalizer deadlock" begin
+        # Test that we avoid finalizer deadlocks like this:
+        #   1. Task A holds the GIL
+        #   2. Task B triggers a PyObject finalizer (e.g. via GC)
+        #   3. Task A waits on Task B
+        #   4. Task B cannot complete GC and Task A cannot advance -> deadlock
+
+        o = PyObject(42)
+        PyCall.pyincref(o)
+
+        PyCall.@with_GIL begin
+            t = Threads.@spawn begin
+                finalize(o)
+                return true
+            end
+            result = timedwait(() -> istaskdone(t), 5.0)
+            @test result === :ok
+            @test fetch(t) === true
+            @test !isempty(PyCall._deferred_Py_DecRef)
+        end
+        @test isempty(PyCall._deferred_Py_DecRef)
+    end
+
 end

--- a/test/gil.jl
+++ b/test/gil.jl
@@ -39,4 +39,40 @@ using Base.Threads
         @test isempty(PyCall._deferred_Py_DecRef)
     end
 
+    @testset "GIL + GC safepoint deadlock" begin
+        done = Threads.Atomic{Bool}(false)
+
+        # If not protected by a (GC-aware) Julia-level lock, it is possible
+        # to deadlock with the GC + GIL:
+        #   1. Task A holds the GIL
+        #   2. Task B waits to access the GIL
+        #   3. Task A triggers GC
+        #   4. Task B never reaches a safepoint, due to waiting for the GIL.
+        task1 = Threads.@spawn begin
+            while !done[]
+                PyCall.@with_GIL begin
+                    for _ in 1:10_000
+                        PyObject(0)
+                    end
+                end
+            end
+        end
+
+        task2 = Threads.@spawn begin
+            while !done[]
+                PyCall.@with_GIL begin
+                    for _ in 1:10_000
+                        PyObject(0)
+                    end
+                end
+                GC.gc(true)
+            end
+        end
+
+        result = timedwait(() -> istaskdone(task1) || istaskdone(task2), 3.0)
+        done[] = true
+        timedwait(() -> istaskdone(task1) && istaskdone(task2), 5.0)
+        @test result === :timed_out
+    end
+
 end

--- a/test/gil.jl
+++ b/test/gil.jl
@@ -1,0 +1,15 @@
+using Test, PyCall
+using Base.Threads
+
+@testset "GIL / multi-threading" begin
+    o = PyObject(randn(3,3))
+    t = Threads.@spawn begin
+        # Test that accessing `PyObject` across threads / tasks
+        # does not immediately segfault (GIL is acquired correctly).
+        iob = IOBuffer()
+        println(iob, propertynames(o))
+        str = String(take!(iob))
+        return length(str)
+    end
+    @test fetch(t) != 0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -862,6 +862,7 @@ end
 
 include("test_pyfncall.jl")
 include("testpybuffer.jl")
+include("gil.jl")
 if lowercase(get(ENV, "JULIA_PKGEVAL", "false")) != "true"
     include("test_venv.jl")
     include("test_build.jl")


### PR DESCRIPTION
This should resolve https://github.com/JuliaPy/PyCall.jl/issues/1096 by wrapping every Python API usage in a GIL acquire-release.

If this leads to overhead, we can probably re-export a "manual GIL" version of the API that allows consumers to manage the GIL themselves. In any case, it's worth having proper support for multi-threading.

Fixes https://github.com/JuliaPy/PyCall.jl/issues/1096. Fixes https://github.com/JuliaPy/PyCall.jl/issues/1095. Fixes https://github.com/JuliaPy/PyCall.jl/issues/1090. Fixes https://github.com/JuliaPy/PyCall.jl/issues/1088.
Fixes https://github.com/JuliaPy/PyCall.jl/issues/1078. Fixes https://github.com/JuliaPy/PyCall.jl/issues/1077. Fixes https://github.com/JuliaPy/PyCall.jl/issues/1072. Fixes https://github.com/JuliaPy/PyCall.jl/issues/1083.
Fixes https://github.com/timholy/Revise.jl/issues/989.